### PR TITLE
Add links to GH issues in markdown comments

### DIFF
--- a/docs/components/cp.md
+++ b/docs/components/cp.md
@@ -9,4 +9,7 @@ import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
 When building a IIIF Presentation API viewer, it will be much easier to use Canvas Panel than [the img-service tag](./single-image-service). This is because you are dealing with canvases in manifests - you pass the canvas to Canvas Panel to render, rather than wrrying about its content. It might not even have an image service.
 
+
+TODO: This page needs a discussion of Canvas Panel's types, from https://github.com/digirati-co-uk/iiif-canvas-panel/discussions/33#discussion-3509526
+
 See the [quick start](../intro) to get started.

--- a/docs/examples/1-show-a-canvas.md
+++ b/docs/examples/1-show-a-canvas.md
@@ -6,18 +6,19 @@ sidebar_position: 1
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
-The [quick start](../intro) showed the basics of rendering a canvas. The power of Canvas Panel kicks in when you render a canvas that isn't the 99% use case - when the canvas:
+The [quick start](../intro) showed the basics of rendering a canvas. The power of Canvas Panel is more apparent when you render a canvas that isn't the 99% use case - when the canvas:
 
- - has one image, but doesn't target the whole canvas.
- - more than one image on the canvas (e.g., a digitally reconstituted manuscript)
+ - has one image, but that image doesn't target the whole canvas.
+ - has more than one image on a canvas (e.g., a digitally reconstituted manuscript)
  - has time-based media, text or other resources.
 
-The developer experience is the same - it has to be, because you probably don't know what's on the Canvas. That's the point of using Canvas Panel, to avoid having to _evaluate the scene_ and make complex rendering decisions yourself. 
+The developer experience is the same - it has to be: you probably don't know what's on the Canvas. That's the point of using Canvas Panel, to avoid having to _evaluate the scene_ and make complex rendering decisions yourself. 
 
 Instead, Canvas Panel does the hard work. You can still _respond_ to the scene composition and what the user does with it.
 
 Here the Canvas has several different image sources on it:
 
+<!-- TODO: GH-71 -->
 ```html
 <canvas-panel
    iiif-content="..multiple-content-canvas..."
@@ -27,7 +28,7 @@ Here the Canvas has several different image sources on it:
 
 This can still be rendered as a static image!
 
-
+<!-- TODO: GH-71, GH-56 -->
 ```html
 <canvas-panel
    render="static"
@@ -40,19 +41,23 @@ This can still be rendered as a static image!
 
 By default, Canvas Panel will render HTML5 that uses as much information from the IIIF resource as available to provide accessibility information, using the browser's current language settings to pick from alternate languages if available.
 
+<!-- TODO: GH-91 -->
 The HTML5 `alt`, `aria-label`, `aria-labelledby`, `role` and `title` attributes are available on `<canvas-panel>` and will be carried through to the DOM and from the DOM to the accessibility tree seen by assistive technologies. These attributes can be used for manual control over resulting attributes, to override the defaults that Canvas Panel decides from the IIIF content.
+
+<!-- TODO: GH-91 -->
+> Demonstrate that CP generates `aria-*` attributes for assistive technologies from the IIIF label langauage map(s), using browser settings
 
 For a standard 2D canvas, the canvas panel on the page will assign itself `role="img"`. If the canvas carries text content could be exposed to a screen reader, Canvas Panel provides ways of doing this - see [Handling Text](./handling-text) for more on how to expose text from the canvas (e.g., transcriptions, OCR, captions) to assisitve technologies.
 
 :::question
-Should Canvas Panel, _by default_, render as a static image and only become a zoomable element on interaction? Mousewheel, click, etc. Mousewheel and pan events need to be carefully handled to avoid trapping the user in the element, especially on narrow touch devices like a phone.
+Should Canvas Panel, _by default_, render as a static image and only become a zoomable element on interaction? Mousewheel, click, etc. Mousewheel and pan events need to be carefully handled to avoid trapping the user in the element, especially on narrow touch devices like a phone. <!-- TODO: GH-78 -->
 :::
 
 :::info
 Canvas Panel could, in future, make use of the [Accessibility Object Model](https://wicg.github.io/aom/explainer.html). It needs to be accessible _today_ in browsers that don't support that spec (no browsers support it fully, and those that support parts of it still require that it is manually enabled).
 :::
 
-
+<!-- TODO: GH-91 -->
 ```html title="Telling assistive technologies that the canvas is a decorative element"
 <canvas-panel id="cp"></canvas-panel>
 <script>
@@ -66,7 +71,7 @@ Canvas Panel could, in future, make use of the [Accessibility Object Model](http
 </script>  
 ```
 
-> Show it!
+> Show it! (demonstrates manual override of accessibility defaults, potentially)
 
 ## Server-side Canvas Panel
 

--- a/docs/examples/1-show-a-canvas.md
+++ b/docs/examples/1-show-a-canvas.md
@@ -37,6 +37,9 @@ This can still be rendered as a static image!
 </canvas-panel>
 ```
 
+<!-- TODO GH-55 (task) -->
+> The default value of `render` is "zoom" - this can be set explicitly but is not usually required.
+
 ## Accessibility considerations
 
 By default, Canvas Panel will render HTML5 that uses as much information from the IIIF resource as available to provide accessibility information, using the browser's current language settings to pick from alternate languages if available.

--- a/docs/examples/10-handling-choice.md
+++ b/docs/examples/10-handling-choice.md
@@ -6,7 +6,6 @@ sidebar_position: 10
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
-
 A Canvas have have multiple images. Sometimes, they are all a part of the scene to be rendered and the developer doesn't have to do anything extra - Canvas Panel will just render the scene.
 
 But sometimes, the multiple images form a set of choices, for the user to pick from. Multispectral images are an example of this.
@@ -25,6 +24,7 @@ Usually, if Choice is present at all, it's only one set of choices, for the whol
 
 ## Simple scenario - known choice
 
+<!-- TODO: GH-106 -->
 ```html
 <canvas-panel iiif-content="http://example.org/canvas-1.json" choice-id="http://example.org/choice-1" />
 ```
@@ -70,6 +70,7 @@ In most cases, you won't want to handle a choice until you come across one:
 <script>
   const viewer = document.getElementById('viewer');
 
+  // TODO - this API is not confirmed
   viewer.addEventListener('canvas-choice', (helper) => {
     helper.choices // the choices in the IIIF form.
 

--- a/docs/examples/12-drawing-boxes.md
+++ b/docs/examples/12-drawing-boxes.md
@@ -13,7 +13,9 @@ TODO: need to get a valid source for The Ambassadors or use a different image
 
 :::
 
-You want to highlight a region of the Canvas, and style it. You might have already initially constrained the viewport to a particular part of the canvas (as in [Regions](./regions)).
+## Scenario
+
+You want to highlight a region of the Canvas, and style the way you highlight it. You might have already initially constrained the viewport to a particular part of the canvas (as in [Regions](./regions)).
 
 Consider Canvas Panel showing a painting:
 
@@ -25,7 +27,7 @@ Consider Canvas Panel showing a painting:
 ```
 ![The Ambassadors - full](../../static/img/examples/ambassadors-1.png)
 
-Then showing a detail:
+Then showing a detail via the addition of a `region` attribute:
 
 ```html
 <canvas-panel
@@ -37,8 +39,9 @@ Then showing a detail:
 
 ![The Ambassadors - detail](../../static/img/examples/ambassadors-2.png)
 
-Then highlighting something within that detail:
+Then **highlighting something** within that detail:
 
+<!-- TODO: GH-70, GH-93, GH-94 -->
 ```html
 <canvas-panel
    iiif-content=https://data.ng-london.org.uk/iiif/0CWR-0001-0000-0000/canvas/-1
@@ -69,6 +72,7 @@ The CSS classes are not part of Canvas Panel, they are in your styles under your
 
 In the above examples, the `region` and `highlight` attributes both take string values that can be transformed to [Target](./annotations#target) objects. `highlight` is a convenience attribute, with a convenience css assistant; in code you are doing something more general - you are adding an annotation to the canvas that appears as a highlight. This is such a common scenario that it still has a helper:
 
+<!-- TODO: GH-70, GH-93, GH-94 -->
 ```html
 <canvas-panel id="cp"></canvas-panel>
 <script>
@@ -94,22 +98,15 @@ In the above examples, the `region` and `highlight` attributes both take string 
   
   // here I could ask for anno.toW3CAnno() and get a pure W3C JSON
   
-
    // create anno in vault
    vault.load("my-anno", anno);
-
 
    const displayAnno = new DisplayAnnotation(vault.FromRef("my-anno"));
    displayAnno.cssClass = "red-box";
        
-   cp.DisplayAnnotations.add(displayAnno);
-   
-   // could go-native here with 
-   // cp.worldObject.appendChild( ... );
-
+   cp.DisplayAnnotations.add(displayAnno); // TBC, see Issue #94
 </script> 
 ```
-
 
 
 The highlight region might also be defined by SVG.

--- a/docs/examples/13-rendering-links.md
+++ b/docs/examples/13-rendering-links.md
@@ -6,8 +6,7 @@ sidebar_position: 13
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
-
-In any canvas rendering scenario, if the canvas has linking annotations available, render them as hyperlinks on the image surface.
+In any canvas rendering scenario, if the canvas has `linking` annotations available, we need to render them as hyperlinks on the image surface.
 
 ```js title="An example linking annotation"
 {
@@ -28,7 +27,7 @@ In any canvas rendering scenario, if the canvas has linking annotations availabl
 }
 ```
 
-Note that the `target` of the anno is not the "target" of the link. The annotation `target` is the relevant part of the canvas, and the `body` of the anno is used to generate the appropriate href. Here it's just a link but it could be an object:
+Note that the `target` of the annotation is not the "target" of the link. The annotation `target` is the relevant part of the canvas, and the `body` of the annotation is used to generate the appropriate href. Here it's just a link but it could be an object:
 
 ```js title="Alternate representation of body"
 {
@@ -38,7 +37,7 @@ Note that the `target` of the anno is not the "target" of the link. The annotati
 }
 ```
 
-There are different scenarios here.
+There are several different scenarios to consider here.
 
 ## Adding links to the Canvas
 
@@ -46,6 +45,7 @@ One is similar to explicit highlighting, as [Drawing boxes](./drawing-boxes) - t
 
 Here we are adding a linking annotation to the canvas:
 
+<!-- TODO: GH-107, GH-94 -->
 ```html
 <canvas-panel id="cp"></canvas-panel>
 <script>
@@ -86,6 +86,7 @@ But what if the body is a canvas within a manifest? Even if CP recognises that, 
 
 How about you can provide a function to process the body?
 
+<!-- TODO: GH-107, GH-94 -->
 ```js title="stepping in to generate the link"
 // cp will call this. The Body class is like Target - it's not a raw W3C anno body, 
 // it's a wrapper with helpers.
@@ -108,9 +109,15 @@ const options = {
 
 ## Dealing with existing linking annotations
 
+> Show it! - this is a demo of the default behaviour of Canvas Panel showing a canvas that has an annotations property that links to (not inline) a page of `linking` annotations. TBC - the default behaviour might be to do nothing; we might have to follow the link ourselves, and do something to cause the annos to be rendered.
+
 The second scenario is where the annotations are already present in the IIIF resource, or linked from it via the canvas `annotations` property.
 
-Canvas panel's default behaviour is (via vault) to follow `annotations`. So it has raw W3C annos available. Then we need to handle them. (Does CP have them? What does that mean - that they are loaded into the vault? They aren't drawn yet).
+Canvas panel's default behaviour is (via vault) to follow `annotations`.
+
+> That isn't true? You have to load them manually - see [Vault introduction](../../docs/components/vault).
+
+So it has raw W3C annos available. Then we need to handle them. (Does CP have them? What does that mean - that they are loaded into the vault? They aren't drawn yet).
 
 It can do this the same way manually added links, highlights etc are done, with DisplayAnnotation, but that needs some assistance and control.
 
@@ -120,14 +127,15 @@ The painting annos, inline in the canvas (usually, but might require a dereferen
 
 Other annotations are linked via the `annotations` property.
 
-If they have the motivation `supplementing`, they will be fed down a different path. They are possibly transcriptions, OCR text, captions, etc. Handle this somewhere else. See #15 
+If they have the motivation `supplementing`, they will be fed down a different path. They are possibly transcriptions, OCR text, captions, etc. Handle this somewhere else. See [Handling text](./handling-text) .
 
 All other annotations could just be each wrapped with DisplayAnnotation instances and cp would attempt to draw them
 
+
+<!-- TODO: GH-107, GH-94 -->
 ```html
 <!-- prevent default follow behaviour -->
 <canvas-panel id="cp" follow-annotations="false" />
-
 
 <!-- allow cp default behaviour in anno rendering, but at least provide some styles -->
 <canvas-panel id="cp"

--- a/docs/examples/14-annotations.md
+++ b/docs/examples/14-annotations.md
@@ -9,10 +9,12 @@ import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
 The underlying Hyperion framework is opinionated about IIIF: it enables you to code directly against the IIIF Presentation 3.0 data model. To enable this, it provides helper functions and normalisation services, so that even if you load IIIF 2.1 resources, you can code against them as if they were version 3 resources. Hyperion+Vault gives you access to a managed, normalised IIIF 3 world, as if everyone's IIIF was perfectly on-spec and version 3.
 
-In IIIF, content is associated with canvases through Annotations, using the W3C Web Annotaton Data Model. This model has a wider scope than IIIF, and unlike the Presentation 3.0 specification it allows the same idea to be expressed in different ways. It's also JSON-LD 1.0, not 1.1 like IIIF. With annotations, there's no further spec to normalise the data to, and using annotations directly reintroduces the overly defensive, always-checking style Hyperion aims to avoid.
+In IIIF, content is associated with canvases through [Annotations](https://iiif.io/api/presentation/3.0/#56-annotation), using the [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/). This model has a wider scope than IIIF, and unlike the Presentation 3.0 specification it allows the same intention to be expressed in different ways. It's also JSON-LD 1.0, not 1.1 like IIIF. With annotations, there's no further specification to normalise the data to, and using annotations directly reintroduces the overly defensive, always-checking style Hyperion aims to avoid.
 
-For this reason, Hyperion _does_ expose annotations through its own type system. It can't hope to coerce every _possible_ annotation into its own types, but it does attempt to do this for annotation styles commonly encountered in IIIF development scenarios, especially (but not exclusively) annotations on canvases. Hyperion also gives you access to the original annotation fields if you really need them, but generally you shouldn't.
+For this reason, Hyperion **exposes annotations through its own type system**. It can't hope to coerce every _possible_ annotation into its own types, but it does attempt to do this for annotation styles commonly encountered in IIIF development scenarios, especially (but not exclusively) annotations on Canvases. Hyperion also gives you access to the original annotation fields if you really need them, but generally you shouldn't need to do this.
 
+<!-- TODO: GH-94 -->
+<!-- this whole section depends on the way we approach annotations and helper classes -->
 ## Annotation Data
 
 Hyperion will attempt to wrap any annotations it finds with its own Annotation class - or rather, an instance of a motivation-specific class:
@@ -32,6 +34,7 @@ The Annotation class makes use of two further helper classes:
 
 These reflect the W3C Annotation Model's `body` and `target` properties, but are accessed via the properties `bodies` and `targets` (both _arrays_) on Hyperion's `Annotation` class.  Usually there is one of each, but there can be more than one _target_, more than one _body_, and also, no _body_. The original `body` and `target` properties are available as their original JSON-LD representations. 
 
+<!-- TODO: GH-94 -->
 Hyperion attempts to coerce the found annotation bodies and targets into normalised representations common in IIIF development. If it can't do this it leaves the W3C body or target as-is and doesn't add to the `bodies` or `targets` array.
 
 ## Annotation Display
@@ -40,12 +43,17 @@ As well as Hyperion providing types to help with annotation _data_, Canvas Panel
 
   - `DisplayAnnotation`
 
-The Hyperion classes represent the data - the annotation content, the canvas or part of canvas it targets. `DisplayAnnotation` represents the Annotation _rendered in the user interface_ - the element rendered on the canvas surface, that might have styles, behaviours and user interaction events. `DisplayAnnotation` is where the W3C Model meets the DOM in the browser. A W3C Hyperion `Annotation` can't have a CSS Class, but the Canvas Panel `DisplayAnnotation` that wraps it can.
+The Hyperion classes represent the data - the annotation content, the canvas or part of canvas it targets. `DisplayAnnotation` represents the Annotation _rendered in the user interface_ - the element rendered on the canvas surface, that might have styles, behaviours and user interaction events. 
+
+> `DisplayAnnotation` is where the W3C Model meets the DOM in the browser
+
+A W3C Hyperion `Annotation` can't have a CSS Class, but the Canvas Panel `DisplayAnnotation` that wraps it can.
 
 Canvas Panel also defines `TransitionOptions` - a class used to define how the canvas navigates from one Annotation or state to another, e.g., for guided viewing.
 
 ## Target
 
+<!-- TODO: GH-108 -->
 **Target** is a standardised object representing a spatial and/or temporal target on a canvas, from the various forms that could take in Annotation JSON. Hyperion will parse these from W3C and Open Annotation content.
 
 ```json
@@ -54,9 +62,9 @@ Canvas Panel also defines `TransitionOptions` - a class used to define how the c
 
 or
 
-```
+```json
 "target": { 
-  "id": http://example.org/canvas-1.json", 
+  "id": "http://example.org/canvas-1.json", 
   "refinedBy": "#xywh=1,2,3,4" 
 }
 ```
@@ -301,5 +309,8 @@ Body and Target are probable subclasses of some other resource.
 
 in [linking example](rendering-links) there's an example of `body.getContentState()` but a Target could have that too; there's some base class. A body might be a plain string, or a plain hyperlink.
 
+## Intermediate annotations
+
+Need an example for https://github.com/digirati-co-uk/iiif-canvas-panel/issues/94#issuecomment-996670694
 
 <GitHubDiscussion ghid="33" />

--- a/docs/examples/15-handling-text.md
+++ b/docs/examples/15-handling-text.md
@@ -2,6 +2,7 @@
 sidebar_position: 15
 ---
 
+<!-- TODO: GH-81 -->
 # Handling Text
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
@@ -15,6 +16,7 @@ For spatial content, the OCR formats METS-ALTO and hOCR should also be supported
 For temporal content, WebVTT should be supported.
 In both cases the content in these formats can be translated into something that targets the canvas the same way W3C annos do.
 
+<!-- TODO: GH-109 -->
 ## Text rendering _outside_ the canvas
 
 See https://canvas-panel.digirati.com/developer-stories/viewer1.html
@@ -58,6 +60,7 @@ If more than one source of supplementing annos is available, or pseudo-annotatio
 
 The annotation listing component doesn't behave differently for hover, select, scroll; any of these events has a corresponding annotation as data (the annotation clicked on or scrolled to); the glue code navigates to and/or highlights the corresponding annotation target. This might be a navigation in _time_.
 
+<!-- TODO: GH-81 -->
 ## Text rendering _on_ the canvas
 
 This is described in https://canvas-panel.digirati.com/developer-stories/collaboration.html, but there is a real implementation of this now - https://github.com/dbmdz/mirador-textoverlay - which works very well and solves many subtle interaction issues.

--- a/docs/examples/16-reacting-to-the-user.md
+++ b/docs/examples/16-reacting-to-the-user.md
@@ -2,6 +2,7 @@
 sidebar_position: 16
 ---
 
+<!-- TODO: GH-110 -->
 # Reacting to the user
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";

--- a/docs/examples/2-responsive-image.md
+++ b/docs/examples/2-responsive-image.md
@@ -6,39 +6,46 @@ sidebar_position: 2
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
-
+<!-- TODO: GH-79 -->
 Using IIIF for responsive images is a natural fit. Canvas Panel makes this easy, and can populate the HTML5 `srcset` attributes that you need to do when using the HTML5 [picture element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture). The tag knows about available sizes because it has the image service (or the canvas). There is typically a media query involved, too:
 
 `media="(min-width: 600px)"`
 
-The developer can step in aqnd control this process. Here we start by using the `<img-service>` tag for contrast - but `<canvas-panel>` takes the same content.
+The developer can step in and control this process. Here we start by using the `<img-service>` tag for contrast - but `<canvas-panel>` takes the same content.
 
-```html
-// use the service sizes property, if present, and/or default "break points" to generate a sensible picture element without any further thinking for the developer:
+<!-- TODO: GH-79 -->
+```html 
+<!-- use the service sizes property, if present, and/or default "break points" 
+     to generate a sensible picture element without any further thinking for the developer: -->
 <img-service src="http://..." render="responsive" />
+```
 
-// most of the time, it should be OK just to use the above form and let the tag do the hard work.
+Most of the time, it should be OK just to use the above form and let the tag do the hard work.
+Sometimes you want to provide specific sizes for particular media queries. This is where `img-service` and `canvas-panel` syntax meets HTML5 responsive image syntax: The `size` attribute here is the `/size/` slot in the IIIF Image API parameters.
 
-// provide media queries and corresponding size values; the syntax is the size slot in the Image API.
+<!-- TODO: GH-79 -->
+```html
 <img-service src="https://..." render="responsive">
   <source media="(min-width: 800px)" size="800,">
   <source media="(min-width: 1600px)" size="1600,">
 </img-service>
+```
 
-// the media queries just pass through to the rendered <picture> element, we're not trying to be clever and interpret them ourselves.
+The media queries just pass through to the rendered HTML 5 <picture> element.
 
-// you can also specify regions (region defaults to full):
+You can also specify _regions_, again using IIIF Image API syntax. This attribute defaults to "full":
 
+```html
 <img-service src="http://..." render="responsive">
   <source media="(min-width: 800px)" region="120,850,2100,2000", size="800,">
   <source media="(min-width: 1600px)" region="full" size="1600,">
 </img-service>
+```
 
-// note that while the rendered picture element would include an <img /> tag, we obviously don't need one in this component, it has all the info it needs.
+We use the same syntax for canvas panel, _even when we're not necessarily dealing with an image service_ - as long as the canvas has width and height (i.e., this doesn't make sense for an audio-only canvas):
 
-// What about when this is a canvas?
-// can we use the same syntax completely even though we're not necessarily dealing with an image service? Region and size work for 2D canvases too..
-
+<!-- TODO: GH-79 -->
+```html
 <canvas-panel iiif-content="..">
   <source media="(min-width: 800px)" region="120,850,2100,2000", size="800,">
   <source media="(min-width: 1600px)" region="full" size="1600,">

--- a/docs/examples/2-responsive-image.md
+++ b/docs/examples/2-responsive-image.md
@@ -31,7 +31,7 @@ Sometimes you want to provide specific sizes for particular media queries. This 
 </img-service>
 ```
 
-The media queries just pass through to the rendered HTML 5 <picture> element.
+The media queries just pass through to the rendered HTML 5 `picture` element.
 
 You can also specify _regions_, again using IIIF Image API syntax. This attribute defaults to "full":
 

--- a/docs/examples/3-other-options.md
+++ b/docs/examples/3-other-options.md
@@ -6,18 +6,22 @@ sidebar_position: 3
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
+## Preferred Formats
 
-If there are version 3 image services, and if they supply a `preferredFormats` property, Canvas Panel (and `<img-service/>`) will use the preferred format(s).
+The `preferredFormats` property is a feature of the [IIIF Image API version 3](https://iiif.io/api/image/3.0/#55-preferred-formats).
 
-The user can also set a preferred format manually, which works for version 2 image services, too:
+It allows the publisher to suggest that the client ask for a different format from the default JPEG. For example, if publishing line art, `.png` might be better.
 
+Canvas Panel (and `<img-service/>`) will use the preferred format(s) automatically if consuming a IIIF Image API 3 endpoint (and if they are available), but it also supports the concept as a client property; using Canvas Panel on a web page you can state a preference _as a consumer_, regardless of whether the server has this property. This works for Image API version 2 services as well:
+
+<!-- TODO: GH-68 -->
 ```html
 <canvas-panel iiif-content=".." preferred-formats="png"></canvas-panel>
-<canvas-panel iiif-content=".." preferred-formats="webp,jpg"></canvas-panel>
+<canvas-panel iiif-content=".." preferred-formats="webp,jpg"></canvas-panel><!-- equivalent to just "webp" -->
 ```
 
 > Show it!
 
-If this format is not available the tag will fall back to the default jpg.
+If the format is not available, the tag will fall back to the default jpg.
 
-<GitHubDiscussion ghid="3" />
+<GitHubDiscussion ghid="45" />

--- a/docs/examples/7-more-regions.md
+++ b/docs/examples/7-more-regions.md
@@ -6,7 +6,6 @@ sidebar_position: 7
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
-
 ![Excerpt from exhibition catalogue](../../static/img/examples/riley.png)
 
 This image shows the sort of widget that might be used in a content management system, where the editor can select either a whole image (the top one) or a detail of a larger image (the bottom one), and accompany that image with some additional HTML.
@@ -15,7 +14,7 @@ This is an example of using Canvas Panel as a component of some other piece of s
 
 ## Using content state
 
-In this one, https://quire.getty.edu/iiif-snippets/boy-with-straw-hat.json is a content state at a URL. This will have been made by an editor at content-creation time, using #18. Loading it will load a full JSON content state that looks like this:
+In the following, `https://quire.getty.edu/iiif-snippets/boy-with-straw-hat.json` is a content state at a URL. This will have been made by an editor at content-creation time, using a [Content State Selector](../../docs/applications/content-state-selector). It's a full JSON content state that looks like this:
 
 ```json
 {
@@ -73,7 +72,7 @@ asnieres-detail-boy-with-straw-hat.json">
           iiif-content="https://quire.getty.edu/iiif-snippets/
 asnieres-detail-boy-with-straw-hat.json"
            />
-</a>  ​
+</a>
 ```
 
 (Both canvas panel and the anchor tag need accessibility attributes here, omitted for brevity)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -68,6 +68,7 @@ The addition of `render="static"` changes the behaviour of the component on the 
 
 The `canvas-id` and `manifest-id` attributes are helper aliases for two more general purpose mechanisms for loading a Canvas into Canvas Panel:
 
+<!-- TODO: GH-55 - tasks -->
 ```html
 <canvas-panel
    iiif-content="https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0001.JP2"
@@ -82,29 +83,37 @@ The `iiif-content` attribute is here set to a Canvas `id`, and `partof` is the M
 
 `iiif-content` can take a Canvas id - but it can also take any value that is a valid [IIIF Content State](https://iiif.io/api/content-state/). So it could be a content state Annotation that points at a particular part of a Canvas, with a `partof` reference included in the Annotation (meaning that only the single `iiif-content` attribute is needed). This includes content states in encoded form, e.g., a stored bookmark or a search result linking into a viewer:
 
+
+<!-- TODO: GH-72 -->
 ```html
 <canvas-panel iiif-content="JTdCJTI.....EJTdE"></canvas-panel>
 ```
 
 > Show It!
 
-> Inspect this content state in a content state decoder (TBC)
+<!-- TODO: GH-82 (task) -->
+> Inspect this content state in a [content state decoder](https://base64url.herokuapp.com/?iiif-content=SGVsbG8lMkMlMjBXb3JsZA)
+
 
 ### Programming Canvas Panel
 
 You can also work with the Canvas from script. This is more typical in client-side applications. The attribute-based approach is more useful in rendering IIIF content server-side. You can tell Canvas Panel to do the same thing as the attributes above like this:
 
+<!-- TODO: GH-58, GH-59, GH-66 -->
 ```html
 <canvas-panel id="cp"></canvas-panel>
 <script>   
-   //....
-   const cp = document.getElementById("cp");
-   cp.setAttribute("render", "responsive"); // we've seen default (zoom) and static, here's another mode
-   const vault = HyperionVault.globalVault(); // Vault simplifies access to IIIF resources
-   await vault.loadManifest("https://iiif.wellcomecollection.org/presentation/b18035723");
-   cp.setCanvas("https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0001.JP2");
-   //...
-</script>  
+    const cp = document.getElementById("cp");
+    cp.setAttribute("render", "responsive"); // we've seen default (zoom) and static, here's another mode
+    const vault = HyperionVault.globalVault(); // Vault simplifies access to IIIF resources
+    
+    async function main(){
+        await vault.loadManifest("https://iiif.wellcomecollection.org/presentation/b18035723");
+        cp.setCanvas("https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0001.JP2");
+    }
+
+    main();
+</script>   
 ```
 
 > Show it!

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## What is Canvas Panel?
 
-Canvas Panel is a [Web Component](https://developer.mozilla.org/en-US/docs/Web/Web_Components) that renders a IIIF Canvas and the annotations on it. If you already know what Canvases and Annotations are you are ready to get started. If not, [here's a brief introduction](../about) with links to more learning resources.
+Canvas Panel is a [Web Component](https://developer.mozilla.org/en-US/docs/Web/Web_Components) that renders a [IIIF Canvas](https://iiif.io/api/presentation/3.0/#53-canvas) and the annotations on it. If you already know what Canvases and Annotations are you are ready to get started. If not, [here's a brief introduction](../about) with links to more learning resources.
 
 Canvas Panel is not a IIIF Viewer, like Mirador or Universal Viewer. It's not a full application - it's a component of _your_ application. On its own, Canvas Panel doesn't render a IIIF Manifest - but it can be used as the _rendering surface_ in any kind of IIIF application you want to build. You can see Canvas Panel used this way in some of the [demo applications](../docs/applications/simple-viewer). It also provides a powerful API for drawing annotations on the canvas and responding to user interaction with the canvas.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,13 +14,12 @@ You can see how to use Canvas Panel to build a [Manifest Viewer](../../docs/appl
 
 ## How do I get Canvas Panel?
 
-
 An easy way to try things out is to simply include a reference to Canvas Panel on (CDN).
 
 ```html
 <html>
 <head>
-    <script src="https://cdn.js/....(example).../canvas-panel.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest/dist/bundle.js"></script>
 </head>
 <body>
     <h1>Canvas Panel</h1>
@@ -52,6 +51,7 @@ This shows Canvas Panel loading a manifest, finding a particular Canvas, and ren
 
 You can also render canvases as static images, without the pan and zoom behaviour:
 
+<!-- TODO: GH-56 -->
 ```html
 <canvas-panel
    render="static"

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -6,38 +6,52 @@ title: About Canvas Panel
 
 ## What is Canvas Panel? 
 
-In IIIF, content - images, text, video, captions, annotations - is assembled on one or more Canvases. A Canvas is like a PowerPoint slide - the virtual space that your content and annotations are arranged on. A `<canvas-panel>` component on a web page renders one IIIF Canvas, and provides properties, events and functions to support user interaction with the content on the Canvas - in IIIF and Web Annotation terms.
+As the [Quick start](../docs/intro) says:
 
-Canvas Panel is not a viewer (not on its own, anyway) - it has no concept of digital objects, or IIIF Manifests and Ranges. You can quickly build viewers with it - there are some examples on this site. 
+> Canvas Panel is a [Web Component](https://developer.mozilla.org/en-US/docs/Web/Web_Components) that renders a [IIIF Canvas](https://iiif.io/api/presentation/3.0/#53-canvas) and the annotations on it.
+
+But what does this mean?
+
+[IIIF](https://iiif.io/) is a set of standards for working with digital objects on the web, such as digitised books, manuscripts, artworks, movies and audio. It's typically used by galleries, libraries, archives and museums to present their collections and make them _interoperable_ - they become available to software such as viewers, annotation tools, digital exhibits and more.
+
+The unit of distribution of IIIF is the [Manifest](https://iiif.io/api/presentation/3.0/#52-manifest) - a JSON document, that contains a sequence of one or more _Canvases_, with accompanying metadata and (sometimes) structural information. A Canvas is like a PowerPoint slide - the virtual space that content is arranged on, and a Manifest has one or more "slides" - for example, one for each page of a book.
+
+Existing IIIF viewers know how to load a Manifest, they generate a user interface for navigating around the object, and sometimes creating new content through annotation. 
+
+A `<canvas-panel>` component on a web page renders one IIIF Canvas, and provides properties, events and functions to support user interaction with the content on the Canvas - in IIIF and Web Annotation terms. 
+
+Canvas Panel is not a viewer (not on its own, anyway) - it has no concept of digital objects, or IIIF Manifests and structure. But you can quickly build viewers with it - there are some examples on this site. 
 
 Canvas Panel is a _web component_ abstraction built to hit a sweet spot of functionality and rapid development, on top of more general purpose libraries and components for loading IIIF content, and rendering images, text and AV.
 
-Canvas Panel is to a IIIF Canvas as OpenSeadragon or Leaflet are to the IIIF Image API.
+Canvas Panel is to a IIIF Canvas as [OpenSeadragon](https://openseadragon.github.io/examples/tilesource-iiif/) or [Leaflet](https://training.iiif.io/intro-to-iiif/LEAFLET-IIIF.html) are to the IIIF Image API. Many viewers use one or other of those libraries to deal with tiled images.
 
 ## Why not just use OpenSeadragon?
 
-Most canvases have just one image, that fills the canvas, and usually that image has an associated IIIF Image service. To show this using OpenSeadragon is easy - inspect the canvas, find the one image, find its image service, and pass that to OpenSeadragon. This is not many lines of code.
+Most canvases have just one image, that fills the canvas, and usually that image has an associated IIIF Image service. To show this using OpenSeadragon is easy - inspect the canvas, find the one image, find its image service, and pass that to OpenSeadragon. This is not many lines of code. A simple IIIF viewer that is capable of showing the vast majority of one-full-image-per-canvas IIIF content can be built without really considering the role of the Canvas as the place the content lives on.
 
 But as soon as you find a Canvas that has something different, you are on your own.
 
-What if it has a choice of images - for example, a painting photographed ast different wavelengths?
-
-What if the canvas is composed of multiple images - placed in different regions of the coordinate space?
-
-And what about the annotations on the Canvas? What kind of annotations are they? Is text available for the canvas - whether audio or video - that could be used for transcripts and captions?
+ - What if it has a choice of images - for example, a painting photographed ast different wavelengths?
+ - What if the canvas is composed of multiple images - placed in different regions of the coordinate space?
+ - And what about the annotations on the Canvas? What kind of annotations are they? Is text available for the canvas - whether audio or video - that could be used for transcripts and captions?
 
 If you are building an application that might encounter anyone's IIIF content, you don't know up front what content scenarios you might be dealing with. 
 
 Canvas Panel aims to render any Canvas, and give you hooks to code against where that rendering involves user interaction (such as selecting from a choice of images, or handling events on annotations).
 
+More generally, it's a component that allows you to build ad hoc and bespoke IIIF viewing experiences, by providing an abstraction at the right level - the Canvas. It could sit at the heart of a complex multi-feature viewer, but it can also sit at the heart of simple web apps comrpising just a few lines of code.
+
 ## Where did it come from?
 
-(history)
+Canvas Panel began as an [idea in a gist](https://gist.github.com/tomcrane/e03d5b0405cb23f937ef86aa8f2ae575) in 2016. A first pass at a component library to solve common use cases resulted in storytelling and exhibition tools ([old canvas panel examples](https://canvas-panel.digirati.com/#/examples), and a [Medium article about storytelling with IIIF](https://medium.com/digirati-ch/reaching-into-collections-to-tell-stories-3dc32a1772af)).
+
+Digirati's work with the Getty Research Institute on the [Florentine Codex](https://www.getty.edu/research/scholars/digital_art_history/florentine_codex/) has given us a chance to build a realisation of Canvas Panel using the [Hyperion Framework](https://github.com/digirati-labs/hyperion) ([documentation](https://hyperion.stephen.wf/)), a set of libraries for working with IIIF.
 
 ## How do I use it?
 
-You can use Canvas Panel a declarative way, just as HTML tags, for simply showing a canvas. For more control, you can drive it from code, and respond to events.
+You can use Canvas Panel a declarative way, just as HTML tags, for simply showing a canvas. For more control, you can drive it from JavaScript code, have more control of the IIIF loading process, and respond to events as the user interacts with the canvas.
 
-It works with Vault, a library for loading and managing IIIF resources that normalises everything to IIIF Presentation 3.
+It works with [Vault](../docs/components/vault), a library for loading and managing IIIF resources that normalises everything to IIIF Presentation 3.
 
-It has some helper components that might come in useful for application development.
+This site shows Canvas Panel, Vault and helper components being used to solve a wide range of typical use cases for presenting and interacting with digital objects.

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -55,3 +55,7 @@ You can use Canvas Panel a declarative way, just as HTML tags, for simply showin
 It works with [Vault](../docs/components/vault), a library for loading and managing IIIF resources that normalises everything to IIIF Presentation 3.
 
 This site shows Canvas Panel, Vault and helper components being used to solve a wide range of typical use cases for presenting and interacting with digital objects.
+
+## More about IIIF
+
+The iiif.io web site has some great resources for [getting started](https://iiif.io/get-started/).

--- a/src/pages/glossary.md
+++ b/src/pages/glossary.md
@@ -1,9 +1,21 @@
 # Glossary
 
-## Canvas
+### IIIF 
 
-_(Explanation of IIIF Canvas to follow here, building up to Manifest, Annotations etc.)_
+[IIIF](https://iiif.io/), pronounced "triple-eye-eff", is a set of standards for working with digital objects on the web, such as digitised books, manuscripts, artworks, movies and audio. It's typically used by galleries, libraries, archives and museums to present their collections and make them _interoperable_ - they become available to software such as viewers, annotation tools, digital exhibits and more.
 
 ### Manifest
 
+The unit of distribution of IIIF is the [Manifest](https://iiif.io/api/presentation/3.0/#52-manifest) - a JSON document, that contains a sequence of one or more _Canvases_ (see next definition), with accompanying metadata and (sometimes) structural information. A IIIF Viewer loads a Manifest and generates the UI to allow the user to navigate around, e.g., from page to page of a book, or from scene to scene of an opera.
+
+### Canvas
+
+A Canvas is a bit like a PowerPoint slide - the virtual space that content is arranged on. A Manifest has one or more of these "slides" - for example, one for each page of a book - and each slide has content - most commonly, one image filling the whole Canvas. Rather than a Manifest having a simple list of images, it has a sequence of Canvases, and each Canvas has one (or sometimes more) images. This additional layer of abstraction gives IIIF its power.
+
+Unlike a PowerPoint slide, there is no standard shape (aspect ratio) for a Canvas - it usually _represents_ a view of an object such as a page of a book, or a painting, so has the aspect ratio of that page, or that painting. This aspect ratio is expressed as a pair of integers: a Canvas has a width and a height. These establish a simple coordinate system, so we can refer to points and shapes on the canvas, and place images onto the Canvas. 
+
+Starting in version 3, the IIIF Canvas also supports a time dimension. A Canvas can have a duration, as well as (or for audio, instead of) a width and height. This allows time-based media to be presented via IIIF.
+
 ### Annotation
+
+An Annotation is a resource that conforms to the [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/). An annotation can target a IIIF Canvas - either the whole Canvas, or a point, or a rectangle, or a shape, or an extent of time in the Canvas. Most obviously, an Annotation can be used to comment on the Canvas - to say something about a particular region of the Canvas, to transcribe and/or translate a word or line or sentence, to tag a person in a photograph, to provide a caption for spoken words in audio. The Annotation is a mechanism for associating any resource, from a simple string to any resource on the web, with a Canvas or with a region of the Canvas. More subtly, IIIF uses this ability to associate the images, audio and video content of the digital object with the Canvas, rather than use some other mechanism to position content. The annotations used to connect the content of the canvas are called _painting_ annotations (they have the [motivation](https://www.w3.org/TR/annotation-model/#motivation-and-purpose) painting), in contrast to other types of annotation which connect material that _supplements_ the Canvas (such as a transcription), _comments_ on the canvas, _tags_ the canvas, and so on.


### PR DESCRIPTION
Also has numerous tweaks and additions to the documentation text in the examples section.