### PR TITLE
Ensure that # Title is first thing after front matter

### DIFF
--- a/docs/applications/bookreader-viewer.md
+++ b/docs/applications/bookreader-viewer.md
@@ -3,9 +3,10 @@ sidebar_position: 2
 title: Book Reader
 ---
 
+# A Bookreader viewer, with facing pages
+
 import { GitHubIssue } from "../../GitHubDiscussion.js";
 
-# A Bookreader viewer, with facing pages
 
 This example builds on the minimal viewer by adding support for 2-up views - facing pages - and showing simple annotations.
 

--- a/docs/applications/content-state-selector.md
+++ b/docs/applications/content-state-selector.md
@@ -3,9 +3,9 @@ sidebar_position: 2
 title: Content State Selector
 ---
 
-import { GitHubDiscussion } from "../../GitHubDiscussion.js";
-
 # Content State Selector
+
+import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
 You are writing an article and you want to select a [part of some IIIF Image](../../docs/examples/more-regions) to use. You don't need to know how IIIF works. The content state selector is a widget that can be incorporated into a content creation environment (e.g., a plugin for WordPress or some other CMS). In that environment, you load some IIIF resource, navigate to the place you want, (optionally) select a region, and capture the content state. 
 

--- a/docs/applications/server-side.md
+++ b/docs/applications/server-side.md
@@ -2,9 +2,9 @@
 sidebar_position: 4
 ---
 
-import { GitHubDiscussion } from "../../GitHubDiscussion.js";
-
 # Server-side rendering
+
+import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
 Canvas Panel rendering mostly requires a DOM to exist and is not tailored to rendering on the server. However a server-side renderer could be made and used quickly to render out static HTML img tags or similar without the need for Javascript. This would be useful for SEO and also for showing something to the user before the whole page has loaded.
 

--- a/docs/applications/simple-viewer.md
+++ b/docs/applications/simple-viewer.md
@@ -3,9 +3,10 @@ sidebar_position: 1
 title: Simple Viewer
 ---
 
+# Building a Simple Viewer
+
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
-# Building a Simple Viewer
 
 This is a very minimal IIIF viewer that can load a manifest, display thumbnails, and load canvases in response to user navigation through the thumbnails.
 

--- a/docs/applications/text-centric.md
+++ b/docs/applications/text-centric.md
@@ -2,9 +2,9 @@
 sidebar_position: 3
 ---
 
-import { GitHubDiscussion } from "../../GitHubDiscussion.js";
-
 # Text-centric viewer
+
+import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
 This viewer extends [Simple Viewer](./simple-viewer) to add support for:
 

--- a/docs/applications/working-with-react.md
+++ b/docs/applications/working-with-react.md
@@ -2,8 +2,9 @@
 sidebar_position: 11
 ---
 
+# Working with React
+
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
-# Working with React
 
 Intro and examples

--- a/docs/applications/working-with-vue-js.md
+++ b/docs/applications/working-with-vue-js.md
@@ -2,8 +2,9 @@
 sidebar_position: 10
 ---
 
+# Working with Vue.js
+
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
-# Working with Vue.js
 
 Intro and examples

--- a/docs/examples/15-handling-text.md
+++ b/docs/examples/15-handling-text.md
@@ -2,9 +2,9 @@
 sidebar_position: 15
 ---
 
-<!-- TODO: GH-81 -->
 # Handling Text
 
+<!-- TODO: GH-81 -->
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
 

--- a/docs/examples/16-reacting-to-the-user.md
+++ b/docs/examples/16-reacting-to-the-user.md
@@ -2,8 +2,8 @@
 sidebar_position: 16
 ---
 
-<!-- TODO: GH-110 -->
 # Reacting to the user
+<!-- TODO: GH-110 -->
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 


### PR DESCRIPTION
If the front matter doesn't include a title, need to make sure that the H1 `# Title` is the first thing on the page after the close of the Front Matter - before comments and before `import`.