### PR TITLE
adds default slot to seq panel

### DIFF
--- a/packages/canvas-panel/src/web-components/sequence-panel.tsx
+++ b/packages/canvas-panel/src/web-components/sequence-panel.tsx
@@ -142,6 +142,8 @@ export function SequencePanel(props: SequencePanelProps) {
               <slot name="atlas" />
               {/*{contentStateCallback ? <DrawBox onCreate={onDrawBox} /> : null}*/}
             </ViewCanvas>
+            {/* Default slot. */}
+            <slot />
           </SimpleViewerProvider>
         </VirtualAnnotationProvider>
       </VaultProvider>


### PR DESCRIPTION
The issue is that we would like to place controls in a `sequence-panel`, ideally using exactly the same api as `canvas-panel` which accepts a default slot (c.f., https://iiif-canvas-panel.netlify.app/docs/applications/simple-viewer-with-common-features).

It may be that I'm missing something but I thought I would try with comically simple, naive approach in case that would suffice. I did a quick test in storybook and it appears to work as expected.

