### PR TITLE
guard for mismatched image service dimensions

### DIFF
--- a/packages/canvas-panel/src/components/RenderImage/RenderImage.tsx
+++ b/packages/canvas-panel/src/components/RenderImage/RenderImage.tsx
@@ -56,8 +56,8 @@ export function RenderImage({
             viewport={isStatic}
             tiles={{
               id: image.service.id,
-              height: image.height as number,
-              width: image.width as number,
+              height: (image.height != image.service.height ? image.service.height : image.height) as number,
+              width: (image.width != image.service.width ? image.service.width : image.width) as number,
               imageService: image.service as any,
               thumbnail: thumbnail && thumbnail.type === 'fixed' ? thumbnail : undefined,
             }}

--- a/packages/canvas-panel/src/components/RenderImage/RenderImage.tsx
+++ b/packages/canvas-panel/src/components/RenderImage/RenderImage.tsx
@@ -56,8 +56,8 @@ export function RenderImage({
             viewport={isStatic}
             tiles={{
               id: image.service.id,
-              height: (image.height != image.service.height ? image.service.height : image.height) as number,
-              width: (image.width != image.service.width ? image.service.width : image.width) as number,
+              height: (image.height !== image.service.height ? image.service.height : image.height) as number,
+              width: (image.width !== image.service.width ? image.service.width : image.width) as number,
               imageService: image.service as any,
               thumbnail: thumbnail && thumbnail.type === 'fixed' ? thumbnail : undefined,
             }}


### PR DESCRIPTION
This evaluates a canvas resource's embedded image dimensions against what is actually returned by the image service for that resource and adopts the latter should they not match.