### PR TITLE
Update to `@iiif/helpers` from Vault + new Atlas version.

### DIFF
--- a/docs/api-reference/vault.md
+++ b/docs/api-reference/vault.md
@@ -7,16 +7,33 @@ title: Vault
 
 import { GitHubDiscussion } from "../../GitHubDiscussion.js";
 
+Vault is the library used by Canvas Panel to load, normalise and track IIIF
+resources. If using Canvas Panel solely as a tag, controlling its behaviour by
+setting attributes, you don't need to interact with Vault directly. But if you
+are bringing IIIF to Canvas Panel via script, you use Vault to manage IIIF
+resources.
 
-Vault is the library used by Canvas Panel to load, normalise and track IIIF resources. If using Canvas Panel solely as a tag, controlling its behaviour by setting attributes, you don't need to interact with Vault directly. But if you are bringing IIIF to Canvas Panel via script, you use Vault to manage IIIF resources.
+Any IIIF resource loaded into Vault is then available _through_ Vault as
+_normalised_, 100% compliant IIIF Presentation API 3.0, even if it started out
+as IIIF Presentation 2.0, or 2.1. This process of normalisation gives you a
+consistent programming interface, without having to worry about the various
+forms that the JSON-LD can take before version 3 of the Presentation API. It
+also allows you to develop event-driven applications, because you can associate
+event listeners directly with the IIIF resources managed and tracked in Vault.
+You can also _subscribe_ to changes in the data in Vault, reacting to changes in
+the resources managed by Vault.
 
-Any IIIF resource loaded into Vault is then available _through_ Vault as _normalised_, 100% compliant IIIF Presentation API 3.0, even if it started out as IIIF Presentation 2.0, or 2.1. This process of normalisation gives you a consistent programming interface, without having to worry about the various forms that the JSON-LD can take before version 3 of the Presentation API. It also allows you to develop event-driven applications, because you can associate event listeners directly with the IIIF resources managed and tracked in Vault. You can also _subscribe_ to changes in the data in Vault, reacting to changes in the resources managed by Vault.
-
-This documentation site is full of examples showing Vault usage alongside Canvas Panel. But it helps to begin by showing how Vault is used for general IIIF purposes, before introducing its use with Canvas Panel.
+This documentation site is full of examples showing Vault usage alongside Canvas
+Panel. But it helps to begin by showing how Vault is used for general IIIF
+purposes, before introducing its use with Canvas Panel.
 
 ## Installation
 
-If you have Canvas Panel available on your page, you already have Vault, too. But you can use it on its own, without Canvas Panel. See the [installation instructions](../../docs/installation) for the full details. In the following example, Vault is loaded from a CDN, avoiding any need to build or run a server.
+If you have Canvas Panel available on your page, you already have Vault, too.
+But you can use it on its own, without Canvas Panel. See the
+[installation instructions](../../docs/installation) for the full details. In
+the following example, Vault is loaded from a CDN, avoiding any need to build or
+run a server.
 
 The next few examples use this HTML page to help make the demonstration visible.
 
@@ -26,38 +43,45 @@ The next few examples use this HTML page to help make the demonstration visible.
   <head>
     <title>Vault Example</title>
     <style>
-        .container { display: grid; grid-template-columns: auto auto; }
-        img { padding: 0.3em; }
+      .container {
+        display: grid;
+        grid-template-columns: auto auto;
+      }
+      img {
+        padding: 0.3em;
+      }
     </style>
   </head>
   <body>
     <div class="container">
-        <div id="app"></div>
-        <pre id="data"></pre>  
-    </div>    
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault@latest/dist/index.umd.js"></script>
+      <div id="app"></div>
+      <pre id="data"></pre>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
     <script>
+      let manifestUri = "https://digirati-co-uk.github.io/journal.json";
+      const vault = new IIIFHelpers.Vault();
 
-        let manifestUri = "https://digirati-co-uk.github.io/journal.json";        
-        const vault = new IIIFVault.Vault();
+      // a couple of helpers for displaying what we find
+      function show(obj, label) {
+        const data = document.getElementById("data");
+        const sep =
+          "\n\n\n" +
+          (label || "") +
+          " ==========================================\n\n";
+        data.innerHTML = sep + JSON.stringify(obj, null, 2) + data.innerHTML;
+      }
+      function append(element) {
+        document.getElementById("app").appendChild(element);
+      }
 
-        // a couple of helpers for displaying what we find
-        function show(obj, label){
-            const data = document.getElementById("data");
-            const sep = "\n\n\n" + (label || "") + " ==========================================\n\n"
-            data.innerHTML = sep + JSON.stringify(obj, null, 2) + data.innerHTML;
-        }
-        function append(element){
-            document.getElementById("app").appendChild(element);
-        }
-        
-        async function demo(){
-            // ##################################################################
-            // the script snippets in the following examples should be added here
-            // ##################################################################
-        }
+      async function demo() {
+        // ##################################################################
+        // the script snippets in the following examples should be added here
+        // ##################################################################
+      }
 
-        demo();
+      demo();
     </script>
   </body>
 </html>
@@ -65,7 +89,8 @@ The next few examples use this HTML page to help make the demonstration visible.
 
 ## Working with IIIF
 
-The first thing to do is load some IIIF. At the start of this walkthrough we will use [this manifest](https://digirati-co-uk.github.io/journal.json):
+The first thing to do is load some IIIF. At the start of this walkthrough we
+will use [this manifest](https://digirati-co-uk.github.io/journal.json):
 
 ```js
 let manifestUri = "https://digirati-co-uk.github.io/journal.json";
@@ -79,17 +104,29 @@ vault.loadManifest(manifestUri).then(async (manifest) => {
 }
 ```
 
-So we can use it in our demo page like this, slotting into `async function demo(){..}` above.
+So we can use it in our demo page like this, slotting into
+`async function demo(){..}` above.
 
 ```js
 const manifest = await vault.loadManifest(manifestUri);
 show(manifest, "Vault loads a manifest from a URI");
 ```
 
-At first glance, this appears to have just printed out the manifest. But looking closer, the JSON isn't the same.
+At first glance, this appears to have just printed out the manifest. But looking
+closer, the JSON isn't the same.
 
-* All the properties in the Presentation 3.0 API have been filled out, with default `null` or `[]` values, _even if the manifest didn't provide them_. Normalisation to IIIF Presentation 3.0 means that, even when we load Presentation 2.x resources, we don't have to worry about whether they are objects or arrays. Vault's further normalisation means the we don't have to test array properties for null, they will always be there, but may have no members. Anything that could be an array, will be an array, even if it's empty.
-* Child resources in the graph, such as the canvases in `manifest.items`, only have `id` and `type` properties: they are _references_; when we need the full object we can obtain it from Vault using the reference, or the `id` on its own.
+- All the properties in the Presentation 3.0 API have been filled out, with
+  default `null` or `[]` values, _even if the manifest didn't provide them_.
+  Normalisation to IIIF Presentation 3.0 means that, even when we load
+  Presentation 2.x resources, we don't have to worry about whether they are
+  objects or arrays. Vault's further normalisation means the we don't have to
+  test array properties for null, they will always be there, but may have no
+  members. Anything that could be an array, will be an array, even if it's
+  empty.
+- Child resources in the graph, such as the canvases in `manifest.items`, only
+  have `id` and `type` properties: they are _references_; when we need the full
+  object we can obtain it from Vault using the reference, or the `id` on its
+  own.
 
 ```json
 "items": [
@@ -104,7 +141,8 @@ At first glance, this appears to have just printed out the manifest. But looking
     //...
 ```
 
-Vault has flattened and normalised the manifest; we can obtain the full (but still _normalised_) canvas from a _reference_ like this:
+Vault has flattened and normalised the manifest; we can obtain the full (but
+still _normalised_) canvas from a _reference_ like this:
 
 ```js
 const canvas0 = vault.get(manifest.items[0]);
@@ -115,21 +153,21 @@ Or, as a shortcut, just from the `id` like this:
 
 ```js
 let canvas0Id = manifest.items[0].id;
-show(canvas0Id, "The canvas ID, a string URL")
+show(canvas0Id, "The canvas ID, a string URL");
 const canvas0 = vault.get(canvas0Id);
 show(canvas0, "The canvas, using get(id)");
 ```
 
-
-Now we can see the canvas JSON, and also see that its child properties (like `thumbnail`) are also _references_.
+Now we can see the canvas JSON, and also see that its child properties (like
+`thumbnail`) are also _references_.
 
 We can also construct a reference manually:
 
 ```js
 const myRef = {
   id: "https://digirati-co-uk.github.io/journal/canvases/0",
-  type: "Canvas"
-}
+  type: "Canvas",
+};
 const canvas0a = vault.get(myRef);
 show(canvas0a, "Constructing a reference manually");
 console.log(canvas0 === canvas0a); // true ... they are the same object from the vault.
@@ -140,23 +178,28 @@ One reason for doing this is type-checking:
 ```js
 const myBadRef = {
   id: "https://digirati-co-uk.github.io/journal/canvases/0",
-  type: "Manifest"
-}
+  type: "Manifest",
+};
 const canvas0b = vault.get(myBadRef);
 show(canvas0b, "There is no Manifest with that id in Vault!");
 ```
 
-For resources like canvases, you will often want to do something with _all_ of them. If you pass an array of references to `get`, you get an array of objects back:
+For resources like canvases, you will often want to do something with _all_ of
+them. If you pass an array of references to `get`, you get an array of objects
+back:
 
 ```js
 const allCanvases = vault.get(manifest.items);
-show(allCanvases[0], "The first of allCanvases - all obtained in one operation");
+show(
+  allCanvases[0],
+  "The first of allCanvases - all obtained in one operation"
+);
 ```
 
 This `get` function gives us access to any resource in the Manifest:
 
 ```js
-const provider = vault.get(manifest.provider[0]); 
+const provider = vault.get(manifest.provider[0]);
 show(provider, "Provider - an Agent");
 const logo = provider.logo[0]; // A logo for the manifest publisher
 const img = document.createElement("img");
@@ -166,16 +209,17 @@ append(img);
 
 ## Additional helpers
 
-The `vault-helpers` library brings some additional utilities. Add another `script` tag immediately after the existing Vault one, and create a thumbnail _helper_:
+The `vault-helpers` library brings some additional utilities. Add another
+`script` tag immediately after the existing Vault one, and create a thumbnail
+_helper_:
 
 ```html
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault@latest/dist/index.umd.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
     <script>
 
-    let manifestUri = "https://digirati-co-uk.github.io/journal.json";        
-    const vault = new IIIFVault.Vault();
-    const thumbHelper = VaultHelpers.createThumbnailHelper(vault);  // NEW - make a thumbnail helper
+    let manifestUri = "https://digirati-co-uk.github.io/journal.json";
+    const vault = new IIIFHelpers.Vault();
+    const thumbHelper = IIIFHelpers.createThumbnailHelper(vault);  // NEW - make a thumbnail helper
 ```
 
 Now we can use this to help build user interface:
@@ -183,32 +227,45 @@ Now we can use this to help build user interface:
 ```js
 // back in our demo function
 for (const canvas of manifest.items) {
-    const thumb = await thumbHelper.getBestThumbnailAtSize(canvas, {maxWidth:200, maxHeight:200});
-    show(thumb, "This is what the thumbnail helper returns"); // (we'll only see the last one)
-    const img = document.createElement("img");
-    img.src = thumb.best.id; // .best is an Image resource
-    append(img);
+  const thumb = await thumbHelper.getBestThumbnailAtSize(canvas, {
+    maxWidth: 200,
+    maxHeight: 200,
+  });
+  show(thumb, "This is what the thumbnail helper returns"); // (we'll only see the last one)
+  const img = document.createElement("img");
+  img.src = thumb.best.id; // .best is an Image resource
+  append(img);
 }
 ```
 
-The `getBestThumbnailAtSize` is a helper function that will attempt to find the best thumbnail for a resource. In this example, we want to constrain our thumbnails to 200 by 200. The helper will pick the most efficient thumbnail to use. See the [Vault Documentation](https://github.com/atlas-viewer/iiif-image-api/blob/main/src/types.ts#L39-L54) for more details. (TODO - link to thumbnail documentation specifically).
+The `getBestThumbnailAtSize` is a helper function that will attempt to find the
+best thumbnail for a resource. In this example, we want to constrain our
+thumbnails to 200 by 200. The helper will pick the most efficient thumbnail to
+use. See the
+[Vault Documentation](https://github.com/atlas-viewer/iiif-image-api/blob/main/src/types.ts#L39-L54)
+for more details. (TODO - link to thumbnail documentation specifically).
 
 :::info
 
 ### Other helpers
 
-The vault-helpers library includes other helpers, including some used in other parts of this documentation (for example, see `getValue` below). 
+The vault-helpers library includes other helpers, including some used in other
+parts of this documentation (for example, see `getValue` below).
 
-A full list can be found at [https://github.com/IIIF-Commons/vault-helpers](https://github.com/IIIF-Commons/vault-helpers).
+A full list can be found at
+[https://github.com/IIIF-Commons/vault-helpers](https://github.com/IIIF-Commons/vault-helpers).
 
 :::
 
 ## Following links to further resources
 
-For this section we'll introduce a new manifest, that contains links to external annotation pages from each canvas. In this case, the text transcription.
+For this section we'll introduce a new manifest, that contains links to external
+annotation pages from each canvas. In this case, the text transcription.
 
 ```js
-const manifestWithAnnotations = await vault.loadManifest("https://digirati-co-uk.github.io/wunder.json");
+const manifestWithAnnotations = await vault.loadManifest(
+  "https://digirati-co-uk.github.io/wunder.json"
+);
 const canvas10 = vault.get(manifestWithAnnotations.items[10]);
 show(canvas10);
 ```
@@ -217,11 +274,16 @@ show(canvas10);
 
 `vault.load(..)` or `vault.loadManifest(..)`?
 
-Explain how these differ, when you can use the string id and when you can use the { id, type } reference form.
+Explain how these differ, when you can use the string id and when you can use
+the { id, type } reference form.
 
 :::
 
-In vault's view of this canvas, `items[0]` is a reference to an object already loaded, because it was included in the manifest JSON. But `annotations` is not loaded into Vault yet, because it points to an external resource. It's not a reference to something we can get in full from the Vault at the moment, because vault does not have it loaded.
+In vault's view of this canvas, `items[0]` is a reference to an object already
+loaded, because it was included in the manifest JSON. But `annotations` is not
+loaded into Vault yet, because it points to an external resource. It's not a
+reference to something we can get in full from the Vault at the moment, because
+vault does not have it loaded.
 
 ```json
   "items": [
@@ -245,53 +307,62 @@ In vault's view of this canvas, `items[0]` is a reference to an object already l
 
 :::info
 
-> TODO - How can we tell this? If it didn't have a label it would look the same as a ref. 
+> TODO - How can we tell this? If it didn't have a label it would look the same
+> as a ref.
 
 > THIS SECTION NEEDS WORK PENDING SOME VAULT CHANGES:
 
-A user interface might display the labels of any annotation lists here, and offer the user the ability to load them.
+A user interface might display the labels of any annotation lists here, and
+offer the user the ability to load them.
 
-> TODO - Vault needs to include labels on references to optimise this kind of linking.
+> TODO - Vault needs to include labels on references to optimise this kind of
+> linking.
 
 :::
 
-At this point we'll introduce an extra helper function for the demo. While it's easy to get the `label` property, it's not always easy to use it because it is a Language Map, rather than a string. The `getValue` helper gives us a string that we can display to the user:
+At this point we'll introduce an extra helper function for the demo. While it's
+easy to get the `label` property, it's not always easy to use it because it is a
+Language Map, rather than a string. The `getValue` helper gives us a string that
+we can display to the user:
 
 ```js
 // we can safely do things like this without checking to see if canvas10.annotations is null,
 // because Vault normalises array properties to empty arrays.
 
 let loadedAnnoPage; // this will be the last loaded but here we know there's only one
-for(const annoPage of canvas10.annotations)
-{
-    // the .annotations property is an array of 0..n AnnotationPage resources.
-    console.log(VaultHelpers.getValue(annoPage.label)); 
-    // how do we know these are not inline?
-    let embedded = annoPage.items && !vault.requestStatus(annoPage);
-    if(!embedded){
-        console.log("This needs to be loaded");
-        // As a resource external to the manifest, we load annotations specifically, from their id:
-        loadedAnnoPage = await vault.load(annoPage.id);
-        show(loadedAnnoPage, "The dereferenced AnnotationPage");
-    }
+for (const annoPage of canvas10.annotations) {
+  // the .annotations property is an array of 0..n AnnotationPage resources.
+  console.log(IIIFHelpers.getValue(annoPage.label));
+  // how do we know these are not inline?
+  let embedded = annoPage.items && !vault.requestStatus(annoPage);
+  if (!embedded) {
+    console.log("This needs to be loaded");
+    // As a resource external to the manifest, we load annotations specifically, from their id:
+    loadedAnnoPage = await vault.load(annoPage.id);
+    show(loadedAnnoPage, "The dereferenced AnnotationPage");
+  }
 }
 ```
 
-These particular annotations are lines of text, so we are more likely to want access to them all directly:
+These particular annotations are lines of text, so we are more likely to want
+access to them all directly:
 
 ```js
 const lines = vault.get(loadedAnnoPage.items);
 let pageText = [];
-for(const line of lines){
-    const lineBody = vault.get(line.body[0]);
-    pageText.push(lineBody.value);
+for (const line of lines) {
+  const lineBody = vault.get(line.body[0]);
+  pageText.push(lineBody.value);
 }
 show(pageText, "The full text of the page");
 ```
 
-When using Canvas Panel, you will more likely make use of Canvas Panel's API to [work with annotations](../../docs/examples/annotations) on the Canvas. And for annotation scenarios that involve multiple text fragments, such as the lines of text here or captions on a video, Canvas Panel has a companion component called [text-lines](../../docs/future/handling-text), that will bind to these annotations and render them.
-
-
+When using Canvas Panel, you will more likely make use of Canvas Panel's API to
+[work with annotations](../../docs/examples/annotations) on the Canvas. And for
+annotation scenarios that involve multiple text fragments, such as the lines of
+text here or captions on a video, Canvas Panel has a companion component called
+[text-lines](../../docs/future/handling-text), that will bind to these
+annotations and render them.
 
 :::info
 
@@ -300,41 +371,46 @@ When using Canvas Panel, you will more likely make use of Canvas Panel's API to 
 Vault merges the object graph, so if you had a canvas with:
 
 ```json
-{"id": "http://example.org/annotation-page-1", "type": "AnnotationPage"}
+{ "id": "http://example.org/annotation-page-1", "type": "AnnotationPage" }
 ```
 
-And then loaded that data into Vault, and then constructed your own additional annotations in-memory (e.g., in an app), 
-and then called this:
+And then loaded that data into Vault, and then constructed your own additional
+annotations in-memory (e.g., in an app), and then called this:
 
 ```js
-vault.load('http://example.org/annotation-page-1', myInMemoryAnnotations);
+vault.load("http://example.org/annotation-page-1", myInMemoryAnnotations);
 ```
 
-...Vault would _merge_ the annotations in `myInMemoryAnnotations` into the existing `AnnotationPage` object with that `id`.
+...Vault would _merge_ the annotations in `myInMemoryAnnotations` into the
+existing `AnnotationPage` object with that `id`.
 
 :::
 
 ## More Vault features - Metadata
 
-At this stage the `demo()` function is getting a little cluttered. Keeping the rest of the page intact, remove the contents of the demo function and start again with this:
+At this stage the `demo()` function is getting a little cluttered. Keeping the
+rest of the page intact, remove the contents of the demo function and start
+again with this:
 
 ```js
-async function demo(){  
-    // ##################################################################
-    // the script snippets in the following examples should be added here
-    // ##################################################################
+async function demo() {
+  // ##################################################################
+  // the script snippets in the following examples should be added here
+  // ##################################################################
 
-    let manifestUri = "https://digirati-co-uk.github.io/finsbury.json";
-    const manifest = await vault.loadManifest(manifestUri);
+  let manifestUri = "https://digirati-co-uk.github.io/finsbury.json";
+  const manifest = await vault.loadManifest(manifestUri);
 }
 ```
 
-Beyond storing the IIIF Model, Vault's additional functionality is built on the ability to store arbitrary application metadata alongside the IIIF entities.
-Usually this happens under the hood, behind other API calls, but you can also build on this feature yourself:
+Beyond storing the IIIF Model, Vault's additional functionality is built on the
+ability to store arbitrary application metadata alongside the IIIF entities.
+Usually this happens under the hood, behind other API calls, but you can also
+build on this feature yourself:
 
 ```js
 // store some arbitrary information in the vault for this manifest
-vault.setMetaValue([manifest.id, 'MyCustomStorage', 'myKey'], 'myValue');
+vault.setMetaValue([manifest.id, "MyCustomStorage", "myKey"], "myValue");
 // "MyCustomStorage" provides a scope, into which you can put keys and values.
 
 // now retrieve this data from the Vault:
@@ -342,32 +418,44 @@ let resourceMeta = vault.getResourceMeta(manifest.id);
 show(resourceMeta, "stored custom metadata");
 ```
 
-Having stored this data, we can now _subscribe_ to changes in it, via Vault's `subscribe` function - `function subscribe(selector, subscription)`, where `selector` is a function in which you return the particular slice of Vault you want to subscribe to, and `subscription` is a function that Vault will call when that slice changes. 
+Having stored this data, we can now _subscribe_ to changes in it, via Vault's
+`subscribe` function - `function subscribe(selector, subscription)`, where
+`selector` is a function in which you return the particular slice of Vault you
+want to subscribe to, and `subscription` is a function that Vault will call when
+that slice changes.
 
-Vault calls your suscription callback with two arguments: `(selection, vault)`, where `selection` is the part of the state you subscribed to, and `vault` is a ref to Vault itself, 
-so you can handle this callback without an existing reference to vault (e.g., in another library or external code). Often you won't need this second `vault` argument, as in the immediate example below:
+Vault calls your suscription callback with two arguments: `(selection, vault)`,
+where `selection` is the part of the state you subscribed to, and `vault` is a
+ref to Vault itself, so you can handle this callback without an existing
+reference to vault (e.g., in another library or external code). Often you won't
+need this second `vault` argument, as in the immediate example below:
 
 ```js
 const unsubscribe1 = await vault.subscribe(
-    state => state.iiif.meta[manifest.id], // define the selection 
-    selection => show(selection, "selection callback") // handle a change to that selection
+  (state) => state.iiif.meta[manifest.id], // define the selection
+  (selection) => show(selection, "selection callback") // handle a change to that selection
 );
 ```
 
-Vault's `subscribe` returns a function that you can call to unsubscribe, when needed.
+Vault's `subscribe` returns a function that you can call to unsubscribe, when
+needed.
 
 If we start modifying vault, then vault will start calling our subscriptions:
 
 ```js
 // We get an initial callback when first subscribing.
 // Now if we update, we get another:
-await vault.setMetaValue([manifest.id, 'MyCustomStorage', 'myKey'], 'myValue2');
+await vault.setMetaValue([manifest.id, "MyCustomStorage", "myKey"], "myValue2");
 
 // and we can see new metadata:
-await vault.setMetaValue([manifest.id, 'MyCustomStorage2', 'myKey2'], 'myValue2');
+await vault.setMetaValue(
+  [manifest.id, "MyCustomStorage2", "myKey2"],
+  "myValue2"
+);
 ```
 
-Had we been more specific in our selection, we could have focussed on just one "scope". To see this, first clear our existing subscription:
+Had we been more specific in our selection, we could have focussed on just one
+"scope". To see this, first clear our existing subscription:
 
 ```js
 unsubscribe1();
@@ -377,40 +465,64 @@ Now set up a _scoped_ subscription:
 
 ```js
 await vault.subscribe(
-    state => state.iiif.meta[manifest.id]['MyCustomStorage'], // Now listen to just this scope
-    selection => show(selection, "specific selection callback") // handle a change to that selection
+  (state) => state.iiif.meta[manifest.id]["MyCustomStorage"], // Now listen to just this scope
+  (selection) => show(selection, "specific selection callback") // handle a change to that selection
 );
 
 // we see this:
-await vault.setMetaValue([manifest.id, 'MyCustomStorage', 'myKey'], 'myValue3'); 
+await vault.setMetaValue([manifest.id, "MyCustomStorage", "myKey"], "myValue3");
 // but now, we don't see this:
-await vault.setMetaValue([manifest.id, 'MyCustomStorage2', 'myKey2'], 'myValue4'); 
+await vault.setMetaValue(
+  [manifest.id, "MyCustomStorage2", "myKey2"],
+  "myValue4"
+);
 ```
 
 ### Subscribing to IIIF changes
 
-The above shows subscriptions on arbitrary data, but we're more likely to be interested in changes to known IIIF entities in vault. Consider this loading of an annotation page:
+The above shows subscriptions on arbitrary data, but we're more likely to be
+interested in changes to known IIIF entities in vault. Consider this loading of
+an annotation page:
 
 ```js
 const canvas10 = vault.get(manifest.items[10]);
 const annotationPageId = canvas10.annotations[0].id;
 
-// we can subscribe to changes on this Annotation Page:            
+// we can subscribe to changes on this Annotation Page:
 await vault.subscribe(
-    state => {
-        // When this slice of the store changes...
-        const annotationPage = state.iiif.entities.AnnotationPage[annotationPageId];
-        console.log("Vault is obtaining state (anno page has " + annotationPage.items.length + " items).");
-        return annotationPage;
-    },
-    annotationPage => {
-        console.log("(callback on change) " + annotationPage.items.length + " items");
-        show([VaultHelpers.getValue(annotationPage.label), annotationPage.items.length + " items"], "Annotation Page");
-    }
+  (state) => {
+    // When this slice of the store changes...
+    const annotationPage = state.iiif.entities.AnnotationPage[annotationPageId];
+    console.log(
+      "Vault is obtaining state (anno page has " +
+        annotationPage.items.length +
+        " items)."
+    );
+    return annotationPage;
+  },
+  (annotationPage) => {
+    console.log(
+      "(callback on change) " + annotationPage.items.length + " items"
+    );
+    show(
+      [
+        IIIFHelpers.getValue(annotationPage.label),
+        annotationPage.items.length + " items",
+      ],
+      "Annotation Page"
+    );
+  }
 );
 ```
 
-Vault only has the _reference_ to the annotation page at the moment. This is why it has 0 items. So let's load it (in your application the user might be choosing to load in some external annotations; their interaction action triggers a modification of vault data, and the UI can respond). Changes to vault's state from loading resources will be reflected in subscriptions, but if you directly modify vault resources (e.g., property value), this won't trigger a notification. It's OK to modify vault data this way, but to hook into the subscription, it needs to be mutated via `modifyEntityField` as below:
+Vault only has the _reference_ to the annotation page at the moment. This is why
+it has 0 items. So let's load it (in your application the user might be choosing
+to load in some external annotations; their interaction action triggers a
+modification of vault data, and the UI can respond). Changes to vault's state
+from loading resources will be reflected in subscriptions, but if you directly
+modify vault resources (e.g., property value), this won't trigger a
+notification. It's OK to modify vault data this way, but to hook into the
+subscription, it needs to be mutated via `modifyEntityField` as below:
 
 ```js
 console.log("Now going to load the anno page");
@@ -421,40 +533,58 @@ const annoPage = await vault.load(annotationPageId); // This will trigger it str
 // (The event fires and shows that there are now 38 items.)
 
 // now make some changes
-annoPage.label = [{ "en": ["I have changed the label"] }];
+annoPage.label = [{ en: ["I have changed the label"] }];
 // Making a direct change like this is allowed, and updates the data in Vault, but won't notify subscribers.
 // (no event fires, no additional subscriber notification appears)
 
 // This is how you notify subscribers:
-vault.modifyEntityField(annoPage, "label", {  en: ["I have changed the label again"] });
+vault.modifyEntityField(annoPage, "label", {
+  en: ["I have changed the label again"],
+});
 // Now we see the change appear.
 ```
 
-Metadata and subscriptions are the foundation of some of canvas Panel's built in tools. They use Vault's storage facilities to build application functionality. You can do the same. Event Handlers are a good example.
+Metadata and subscriptions are the foundation of some of canvas Panel's built in
+tools. They use Vault's storage facilities to build application functionality.
+You can do the same. Event Handlers are a good example.
 
 ### Event Handlers in Vault
 
-The set of metadata that Vault can track for any resource includes an _event manager_:
+The set of metadata that Vault can track for any resource includes an _event
+manager_:
 
 ```js
-show(vault.getResourceMeta(manifest.id).eventManager, "Event manager for " + manifest.id);
-// undefined 
+show(
+  vault.getResourceMeta(manifest.id).eventManager,
+  "Event manager for " + manifest.id
+);
+// undefined
 
 // Introducing another helper
-const events = VaultHelpers.createEventsHelper(vault);
+const events = IIIFHelpers.createEventsHelper(vault);
 
 // There is no event manager for this entity, yet. But if we start adding event listeners, one wil be created:
-events.addEventListener(manifest, 'onClick', (e) => {
-    console.log("clicked", this);
-})
+events.addEventListener(manifest, "onClick", (e) => {
+  console.log("clicked", this);
+});
 
-// Now we have one - 
-show(vault.getResourceMeta(manifest.id).eventManager, "Event manager for " + manifest.id);
+// Now we have one -
+show(
+  vault.getResourceMeta(manifest.id).eventManager,
+  "Event manager for " + manifest.id
+);
 ```
 
-Vault's eventsHelper is very simply a means of storing event handlers for identified resources - that's all it is, it's not raising these events itself. In an application you might have multiple DOM elements that correspond to IIIF resources (e.g., thumbnail images corresponding to canvases). This mechanism gives you the option of storing event handlers alongside other metadata. In practice this low-level API is unlikely to be convenient for direct use, but it is the basis of Canvas Panel's higher level API functions.
+Vault's eventsHelper is very simply a means of storing event handlers for
+identified resources - that's all it is, it's not raising these events itself.
+In an application you might have multiple DOM elements that correspond to IIIF
+resources (e.g., thumbnail images corresponding to canvases). This mechanism
+gives you the option of storing event handlers alongside other metadata. In
+practice this low-level API is unlikely to be convenient for direct use, but it
+is the basis of Canvas Panel's higher level API functions.
 
-If we add a button to our "app", we can give it an event listener that Vault is storing for us.
+If we add a button to our "app", we can give it an event listener that Vault is
+storing for us.
 
 ```js
 const manifestButton = document.createElement("button");
@@ -462,73 +592,89 @@ manifestButton.innerText = "Click the manifest";
 append(manifestButton);
 
 await vault.subscribe(
-    state => state.iiif.meta[manifest.id],
-    selection => {
-        if (selection && selection.eventManager) {      
-            // selection.eventManager.onClick is an array of event handlers that you can attach to your DOM elements.                 
-            manifestButton.addEventListener("click", selection.eventManager.onClick[0].callback);
-        }
+  (state) => state.iiif.meta[manifest.id],
+  (selection) => {
+    if (selection && selection.eventManager) {
+      // selection.eventManager.onClick is an array of event handlers that you can attach to your DOM elements.
+      manifestButton.addEventListener(
+        "click",
+        selection.eventManager.onClick[0].callback
+      );
     }
-)
+  }
+);
 ```
 
-To conclude this discussion of events, a slightly more realistic example - storing canvases in Vault, and managing click handlers for thumbnails for those canvases.
+To conclude this discussion of events, a slightly more realistic example -
+storing canvases in Vault, and managing click handlers for thumbnails for those
+canvases.
 
-Here we use Vault's metadata subscription to state for a viewer application. If the loaded manifest changes, we want to react to this:
+Here we use Vault's metadata subscription to state for a viewer application. If
+the loaded manifest changes, we want to react to this:
 
 ```js
-vault.setMetaValue(["ViewerState", "LoadedResources", "CurrentManifest"], manifest.id);
+vault.setMetaValue(
+  ["ViewerState", "LoadedResources", "CurrentManifest"],
+  manifest.id
+);
 await vault.subscribe(
-    state => state.iiif.meta["ViewerState"],
-    selection => {
-        if (selection && selection.LoadedResources) {      
-            LoadManifest(selection.LoadedResources.CurrentManifest);
-        }
+  (state) => state.iiif.meta["ViewerState"],
+  (selection) => {
+    if (selection && selection.LoadedResources) {
+      LoadManifest(selection.LoadedResources.CurrentManifest);
     }
-)
+  }
+);
 ```
 
-For clarity, add this `LoadManifest` function to the script after the demo() function. Our click handler for the thumbnails just pulls the corresponding canvas out of Vault and displays the JSON. This is where you could _give the Canvas to Canvas Panel!_
+For clarity, add this `LoadManifest` function to the script after the demo()
+function. Our click handler for the thumbnails just pulls the corresponding
+canvas out of Vault and displays the JSON. This is where you could _give the
+Canvas to Canvas Panel!_
 
 ```js
-async function LoadManifest(manifestId){
-    
-    const manifest = await vault.loadManifest(manifestId); 
-    const events = VaultHelpers.createEventsHelper(vault);
-    const thumbHelper = VaultHelpers.createThumbnailHelper(vault); 
+async function LoadManifest(manifestId) {
+  const manifest = await vault.loadManifest(manifestId);
+  const events = IIIFHelpers.createEventsHelper(vault);
+  const thumbHelper = IIIFHelpers.createThumbnailHelper(vault);
 
-    for(const canvas of manifest.items){
-        // give these handlers a scope, we may wish to have other click handlers for the same canvases elsewhere
-        events.addEventListener(canvas, 'onClick', () => show(vault.get(canvas)), ["Thumbs"]); 
+  for (const canvas of manifest.items) {
+    // give these handlers a scope, we may wish to have other click handlers for the same canvases elsewhere
+    events.addEventListener(canvas, "onClick", () => show(vault.get(canvas)), [
+      "Thumbs",
+    ]);
+  }
+
+  await vault.subscribe(
+    (state) => state.iiif.entities.Manifest[manifestId], // (can't subscribe to [manifest.id].items)
+    (selection, vault) => {
+      // selection is the manifest. When the manifest changes...
+      document.getElementById("app").innerHTML = "";
+      for (const canvas of selection.items) {
+        // ...create an image element for each canvas
+        const thumb = document.createElement("img");
+
+        // You can interact with an eventManager for a resource:
+        // const canvasManager = vault.getResourceMeta(canvas.id).eventManager;
+        // thumb.addEventListener("click", canvasManager.onClick[0].callback);
+
+        // Or use this more convenient API - note we have retrieved the event listeners for our Thumbs scope.
+        const props = events.getListenersAsProps(canvas, "Thumbs");
+        thumb.addEventListener("click", props.onClick);
+
+        // Now set the src of the image to a thumbnail using vault-helpers:
+        thumbHelper
+          .getBestThumbnailAtSize(canvas, { maxWidth: 100 })
+          .then((cvThumb) => (thumb.src = cvThumb.best.id));
+        append(thumb);
+      }
     }
-
-    await vault.subscribe(
-        state => state.iiif.entities.Manifest[manifestId], // (can't subscribe to [manifest.id].items)
-        (selection, vault) => {
-            // selection is the manifest. When the manifest changes...
-            document.getElementById("app").innerHTML = "";
-            for (const canvas of selection.items) {
-                // ...create an image element for each canvas         
-                const thumb = document.createElement("img");
-
-                // You can interact with an eventManager for a resource:
-                // const canvasManager = vault.getResourceMeta(canvas.id).eventManager;
-                // thumb.addEventListener("click", canvasManager.onClick[0].callback);
-                
-                // Or use this more convenient API - note we have retrieved the event listeners for our Thumbs scope.
-                const props = events.getListenersAsProps(canvas, "Thumbs");
-                thumb.addEventListener("click", props.onClick);
-
-                // Now set the src of the image to a thumbnail using vault-helpers:
-                thumbHelper.getBestThumbnailAtSize(canvas, { maxWidth: 100 })
-                            .then(cvThumb => thumb.src = cvThumb.best.id);
-                append(thumb);
-            }
-        }
-    )
+  );
 }
 ```
 
-It may be difficult to see the changes in the Canvas JSON as you click different thumbnails, as the structure is the same for all. Look at the canvas labels to see that the page number is different.
+It may be difficult to see the changes in the Canvas JSON as you click different
+thumbnails, as the structure is the same for all. Look at the canvas labels to
+see that the page number is different.
 
-Read more on Vault here. 
+Read more on Vault here.

--- a/docs/examples/10-handling-choice.md
+++ b/docs/examples/10-handling-choice.md
@@ -4,50 +4,77 @@ sidebar_position: 10
 
 # Handling Choice
 
-import { GitHubDiscussion } from "../../GitHubDiscussion.js";
-import choicesReactSandbox from '@site/sandboxes/choices-react.csb/_load';
-import simpleChoice from '@site/sandboxes/10-choices/simpleChoice.csb/_load';
-import choice1 from '@site/sandboxes/10-choices/choice1.csb/_load';
-import { Sandbox } from '@site/Sandbox';
+import { GitHubDiscussion } from "../../GitHubDiscussion.js"; import
+choicesReactSandbox from '@site/sandboxes/choices-react.csb/\_load'; import
+simpleChoice from '@site/sandboxes/10-choices/simpleChoice.csb/\_load'; import
+choice1 from '@site/sandboxes/10-choices/choice1.csb/\_load'; import { Sandbox }
+from '@site/Sandbox';
 
-A Canvas have have multiple images. Sometimes, they are all a part of the scene to be rendered and the developer doesn't have to do anything extra - Canvas Panel will just render the scene.
+A Canvas have have multiple images. Sometimes, they are all a part of the scene
+to be rendered and the developer doesn't have to do anything extra - Canvas
+Panel will just render the scene.
 
-But sometimes, the multiple images form a set of choices, for the user to pick from. Multispectral images are an example of this.
+But sometimes, the multiple images form a set of choices, for the user to pick
+from. Multispectral images are an example of this.
 
-For further details on this scenario, see the IIIF Cookbook [Choice example](https://preview.iiif.io/cookbook/3333-choice/recipe/0033-choice/). (TODO - replace with published link)
+For further details on this scenario, see the IIIF Cookbook
+[Choice example](https://preview.iiif.io/cookbook/3333-choice/recipe/0033-choice/).
+(TODO - replace with published link)
 
-You don't necessarily need to know in advance that the Canvas has resources with Choice for something to render. In simple scenarios, you might not need to know, because there's nothing you can do about it anyway: let canvas panel make a sensible default choice, because anything more means you need to provide _more_ user interface to deal with the user making one or more choices. At the other end, your app might be sophisticated and allow blending of layers, e.g., to view multispectral captures of paintings.
+You don't necessarily need to know in advance that the Canvas has resources with
+Choice for something to render. In simple scenarios, you might not need to know,
+because there's nothing you can do about it anyway: let canvas panel make a
+sensible default choice, because anything more means you need to provide _more_
+user interface to deal with the user making one or more choices. At the other
+end, your app might be sophisticated and allow blending of layers, e.g., to view
+multispectral captures of paintings.
 
-For the more sophisticated UI, you need to react to the presence of one or more Choices on the canvas. You need to know what choices are available - their labels, ids and their "stacking" order.
+For the more sophisticated UI, you need to react to the presence of one or more
+Choices on the canvas. You need to know what choices are available - their
+labels, ids and their "stacking" order.
 
-You can then render UI for offering the choices to the user - and react to that choice by telling Canvas Panel to update the scene to reflect changes. Your UI component might be _bound_ to Canvas Panel.
+You can then render UI for offering the choices to the user - and react to that
+choice by telling Canvas Panel to update the scene to reflect changes. Your UI
+component might be _bound_ to Canvas Panel.
 
-You might also support blending: "Show the choice with id xxx at 80% opacity AND show the choice with id yyy at 50% opacity, all the others are at 0%".
+You might also support blending: "Show the choice with id xxx at 80% opacity AND
+show the choice with id yyy at 50% opacity, all the others are at 0%".
 
-Usually, if Choice is present at all, it's only one set of choices, for the whole canvas. But it's possible for a scene to be made of multiple content resources each of which have their own set of choices.
+Usually, if Choice is present at all, it's only one set of choices, for the
+whole canvas. But it's possible for a scene to be made of multiple content
+resources each of which have their own set of choices.
 
 ## Simple scenario - known choice
 
 <!-- TODO: GH-106 -->
+
 ```html
-<canvas-panel iiif-content="http://example.org/canvas-1.json" choice-id="http://example.org/choice-1" />
+<canvas-panel
+  iiif-content="http://example.org/canvas-1.json"
+  choice-id="http://example.org/choice-1"
+/>
 ```
 
 <Sandbox stacked project={choice1} />
 
-
-Here the value of `choice-id` is the `id` of the content resource within a set of choices. You don't need to specify which set of choices, in the rare event that there is more than one - although you can specify more than one value:
+Here the value of `choice-id` is the `id` of the content resource within a set
+of choices. You don't need to specify which set of choices, in the rare event
+that there is more than one - although you can specify more than one value:
 
 ```html
-<canvas-panel iiif-content="http://example.org/canvas-1.json" 
-   choice-id="http://example.org/choice-set-a/3, http://example.org/choice-set-b/7" />
+<canvas-panel
+  iiif-content="http://example.org/canvas-1.json"
+  choice-id="http://example.org/choice-set-a/3, http://example.org/choice-set-b/7"
+/>
 ```
 
 ## Before loading
 
-Before you put the `<canvas-panel />` web component on a page, you can first load the manifest into the vault, find out if there is a choice and render a UI.
+Before you put the `<canvas-panel />` web component on a page, you can first
+load the manifest into the vault, find out if there is a choice and render a UI.
 
-In this example, the "choice" event is fired when Canvas Panel detects that a Choice is present on the rendered Canvas.
+In this example, the "choice" event is fired when Canvas Panel detects that a
+Choice is present on the rendered Canvas.
 
 :::tip
 
@@ -57,37 +84,42 @@ The choice event may be fired multiple times as Canvas Panel loads
 
 <Sandbox project={simpleChoice} />
 
-Canvas panel also has the additional helpers for scenarios where you don't want to react to the choice event:
+Canvas panel also has the additional helpers for scenarios where you don't want
+to react to the choice event:
 
 ```js
 cp.setDefaultChoiceIds(ids);
-cp.makeChoice(id, options)
+cp.makeChoice(id, options);
 ```
 
-And you can render a choice directly, with opacity, via attributes (e.g., if generating the markup on the server):
+And you can render a choice directly, with opacity, via attributes (e.g., if
+generating the markup on the server):
 
 ```html
-<canvas-panel iiif-content="http://example.org/canvas-1.json" choice-id="http://example.org/choice-1#opacity=0.5" />
+<canvas-panel
+  iiif-content="http://example.org/canvas-1.json"
+  choice-id="http://example.org/choice-1#opacity=0.5"
+/>
 ```
 
 ## Choice React Example
 
 This is a more realistic use of Canvas Panel's choice-handling capability:
 
-
 <Sandbox project={choicesReactSandbox} />
-
 
 ## Additional choice helper API
 
 There is an additional helper that can be used to extract choices.
 
 ```js
-import { createPaintingAnnotationsHelper } from '@iiif/vault-helpers';
+import { createPaintingAnnotationsHelper } from "@iiif/helpers";
 
 const helper = createPaintingAnnotationsHelper(element.vault);
-const choice = helper.extractChoices("http://example.org/manifest/canvas-1.json");
-// Choice looks like this: 
+const choice = helper.extractChoices(
+  "http://example.org/manifest/canvas-1.json"
+);
+// Choice looks like this:
 // {
 //   type: 'single-choice';
 //   label?: InternationalString;
@@ -99,19 +131,22 @@ const choice = helper.extractChoices("http://example.org/manifest/canvas-1.json"
 // }
 ```
 
-You might want to analyse the canvas even earlier, to decide what UI to render. You need to ensure that the Manifest
-is loaded before you extract the choices for your canvas.
+You might want to analyse the canvas even earlier, to decide what UI to render.
+You need to ensure that the Manifest is loaded before you extract the choices
+for your canvas.
 
-Using this helper gives complete flexibility over choices at the data level, and can happen before anything is rendered to the user.
+Using this helper gives complete flexibility over choices at the data level, and
+can happen before anything is rendered to the user.
 
-Since the `choice-id` attribute also drives the users choice, I could do the following to manually set the choice ID.
+Since the `choice-id` attribute also drives the users choice, I could do the
+following to manually set the choice ID.
 
 ```js
-element.setAttribute('choice-id', 'http://example.org/choice-1')
+element.setAttribute("choice-id", "http://example.org/choice-1");
 
 // or even
 
-element.setAttribute('choice-id', 'http://example.org/choice-1#opacity=20')
+element.setAttribute("choice-id", "http://example.org/choice-1#opacity=20");
 ```
 
 <GitHubDiscussion ghid="10" />

--- a/docs/examples/20-styling.md
+++ b/docs/examples/20-styling.md
@@ -4,11 +4,11 @@ sidebar_position: 20
 
 # Styling
 
-import externalStylesheet from '@site/sandboxes/external-stylesheet.csb/_load';
-import opacity from '@site/sandboxes/20-styling/opacity.csb/_load';
-import opacity2 from '@site/sandboxes/20-styling/opacity2.csb/_load';
-import flexbox from '@site/sandboxes/01-show-canvas/flexbox.csb/_load';
-import { Sandbox } from '@site/Sandbox';
+import externalStylesheet from '@site/sandboxes/external-stylesheet.csb/\_load';
+import opacity from '@site/sandboxes/20-styling/opacity.csb/\_load'; import
+opacity2 from '@site/sandboxes/20-styling/opacity2.csb/\_load'; import flexbox
+from '@site/sandboxes/01-show-canvas/flexbox.csb/\_load'; import { Sandbox }
+from '@site/Sandbox';
 
 <!-- Stephen
 Needs a really good example of how to make it stick to 4 sides of container
@@ -19,33 +19,37 @@ A discussion of styling quirks
 You can also style image services using their image service ID (no canvas ID)
  -->
 
-There are 3 types of object you can style: 
+There are 3 types of object you can style:
 
-* Canvases
-* Annotation pages
-* Annotations
+- Canvases
+- Annotation pages
+- Annotations
 
-As there is no representation of an Annotation Page in the viewer, this style is used as a cascade for styling 
-annotations. Any styles applied to annotation pages will be applied to annotations inside. This allows you to style
-full sets of annotations at once.
+As there is no representation of an Annotation Page in the viewer, this style is
+used as a cascade for styling annotations. Any styles applied to annotation
+pages will be applied to annotations inside. This allows you to style full sets
+of annotations at once.
 
-Canvases only support opacity. Annotations support box styles, but may also have custom CSS applied to them.
+Canvases only support opacity. Annotations support box styles, but may also have
+custom CSS applied to them.
 
-Styles can be applied either by using a **vault helper** or by using a property from the web component. If you use the
-Vault helper you can apply styles prior to rendering your canvas panel. If you use the Vault Helper you should ensure 
+Styles can be applied either by using a **vault helper** or by using a property
+from the web component. If you use the Vault helper you can apply styles prior
+to rendering your canvas panel. If you use the Vault Helper you should ensure
 that you pass in a scope of `atlas` as the 3rd argument.
 
 ## Box styles
 
-There are currently a subset of styles that can be applied to annotations that will be rendered using the HTML canvas
-if that is available. This will improve performance if you have large numbers of annotations being displayed - such
-as OCR annotations.
+There are currently a subset of styles that can be applied to annotations that
+will be rendered using the HTML canvas if that is available. This will improve
+performance if you have large numbers of annotations being displayed - such as
+OCR annotations.
 
 ```ts
 cp.applyStyles(annotationPage, {
-  backgroundColor: 'rgba(255, 0, 0, 0.5)',
-  border: '3px solid blue',
-  outline: '3px solid #000',
+  backgroundColor: "rgba(255, 0, 0, 0.5)",
+  border: "3px solid blue",
+  outline: "3px solid #000",
   opacity: 0.5,
 });
 ```
@@ -74,63 +78,73 @@ interface BoxStyles {
 
 ### States
 
-You can set hover and active states, that support all the above properties. This can be used to create some basic 
-interactivity for your annotations. These should be enough for most cases and avoid de-optimising and using CSS classes
+You can set hover and active states, that support all the above properties. This
+can be used to create some basic interactivity for your annotations. These
+should be enough for most cases and avoid de-optimising and using CSS classes
 directly.
 
 ```ts
 cp.applyStyles(annotationPage, {
-  backgroundColor: 'rgba(255, 0, 0, 0.5)',
-  ':hover': {
-    backgroundColor: 'rgba(255, 0, 0, 1)',
+  backgroundColor: "rgba(255, 0, 0, 0.5)",
+  ":hover": {
+    backgroundColor: "rgba(255, 0, 0, 1)",
   },
-  ':active': {
-    backgroundColor: 'blue',
+  ":active": {
+    backgroundColor: "blue",
   },
 });
 ```
 
 ### Vault helper
 
-If you decide to use [Vault helpers](https://github.com/IIIF-Commons/vault-helpers) you will need to ensure you pass
-in the correct scope when you apply styles.
+If you decide to use
+[Vault helpers](https://github.com/IIIF-Commons/vault-helpers) you will need to
+ensure you pass in the correct scope when you apply styles.
 
 ```ts
-import { createStyleHelper } from '@iiif/vault-helpers';
-import { globalVault } from '@iiif/vault';
+import { createStyleHelper } from "@iiif/helpers";
+import { globalVault } from "@iiif/helpers/vault";
 
 const helper = createStyleHelper(globalVault());
 
 // For box styles.
-helper.applyStyle(annotation, {
-  background: 'red'
-}, 'atlas');
+helper.applyStyle(
+  annotation,
+  {
+    background: "red",
+  },
+  "atlas"
+);
 
 // For setting a class name
-helper.applyStyle(annotation, {
-  className: 'my-custom-style',
-}, 'html');
+helper.applyStyle(
+  annotation,
+  {
+    className: "my-custom-style",
+  },
+  "html"
+);
 ```
 
-
 ### Quirks
+
 Some quirks of the box style.
 
-* You can only use solid borders and outlines
-* Box-sizing is fixed to content-box (so annotations may be shifted by borders)
-* Some styles may not match exactly
-
+- You can only use solid borders and outlines
+- Box-sizing is fixed to content-box (so annotations may be shifted by borders)
+- Some styles may not match exactly
 
 ## CSS Styles
 
-If you would like to add more styles than these options you can set a custom class name instead.
+If you would like to add more styles than these options you can set a custom
+class name instead.
 
 ```ts
-cp.setClassName(annotationPage, 'my-custom-class');
+cp.setClassName(annotationPage, "my-custom-class");
 ```
 
-Canvas panel exists in a web-component, so styles will not work out of the box. You have 3 options for applying
-styles.
+Canvas panel exists in a web-component, so styles will not work out of the box.
+You have 3 options for applying styles.
 
 **1. Using `::part()`, which must be used instead of `.my-custom-class`**
 
@@ -163,28 +177,30 @@ styles.
 
 ## Styling with FlexBox
 
-To demonstrate how canvas panel can flex to fill its container, it's best to open this demo in the code sandbox and then open the preview in a new window.
+To demonstrate how canvas panel can flex to fill its container, it's best to
+open this demo in the code sandbox and then open the preview in a new window.
 
 <Sandbox project={flexbox} />
 
 ## Opacity
 
-You can set the opacity of resources via their `id`. In this case, the `id` of the image resource that is the body of the painting annotation:
+You can set the opacity of resources via their `id`. In this case, the `id` of
+the image resource that is the body of the painting annotation:
 
 <Sandbox project={opacity2} />
 
 You can also set the opacity of a particular item within a Choice:
 
 ```html
-<canvas-panel 
-  iiif-content="http://example.org/canvas-1.json" 
-  choice-id="http://example.org/choice-set-a/3, http://example.org/choice-set-b/7#opacity=0.5" 
-/>                                                       Useful for static rendering -----^
+<canvas-panel
+  iiif-content="http://example.org/canvas-1.json"
+  choice-id="http://example.org/choice-set-a/3, http://example.org/choice-set-b/7#opacity=0.5"
+/>
+Useful for static rendering -----^
 ```
 
 <Sandbox project={opacity} />
 
-Tile rendering is not as optimised when applying opacity. Canvas Panel does not layer multiple tiles when zooming - just one layer of tiles, so no nice blending, otherwise you'd see through to the fallback layers with the opacity.
-
-
-
+Tile rendering is not as optimised when applying opacity. Canvas Panel does not
+layer multiple tiles when zooming - just one layer of tiles, so no nice
+blending, otherwise you'd see through to the fallback layers with the opacity.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -3,71 +3,84 @@ sidebar_position: 1
 title: Installation
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Installation
 
-Canvas panel is made up of several [Web Components](https://www.webcomponents.org/). In order to use the
-components you need to have a `<script/>` tag loaded on your webpage. You can also include them in your existing bundler of choice.
+Canvas panel is made up of several
+[Web Components](https://www.webcomponents.org/). In order to use the components
+you need to have a `<script/>` tag loaded on your webpage. You can also include
+them in your existing bundler of choice.
 
 The provided Web Components are as follows:
 
-* `<canvas-panel />` - this is the primary web component, used for rendering any single IIIF canvas.
-* `<image-service />` - this is a web component that can be used without a IIIF manifest and only an Image service.
-* `<sequence-panel />` - This is a web component that can show a sequence of Canvases either from a Manifest or a Range.
-
+- `<canvas-panel />` - this is the primary web component, used for rendering any
+  single IIIF canvas.
+- `<image-service />` - this is a web component that can be used without a IIIF
+  manifest and only an Image service.
+- `<sequence-panel />` - This is a web component that can show a sequence of
+  Canvases either from a Manifest or a Range.
 
 Canvas panel also uses a few libraries to provide IIIF functionality.
 
-* [Vault](https://github.com/IIIF-Commons/vault) is the library used by Canvas Panel to load, normalise and track IIIF resources. 
-* [Vault-helpers](https://github.com/IIIF-Commons/vault-helpers/) contains additional utilities for working with IIIF resources, such as `getLabel` and `getThumbnail`.
-* [Canvas Panel](https://github.com/digirati-co-uk/iiif-canvas-panel) is the web component. Its distribution includes vault and the various web components.
-* [IIIF Image API](https://github.com/atlas-viewer/iiif-image-api) is a utility library for working with IIIF Image resources
-
+- [Vault](https://github.com/IIIF-Commons/vault) is the library used by Canvas
+  Panel to load, normalise and track IIIF resources.
+- [Vault-helpers](https://github.com/IIIF-Commons/vault-helpers/) contains
+  additional utilities for working with IIIF resources, such as `getLabel` and
+  `getThumbnail`.
+- [Canvas Panel](https://github.com/digirati-co-uk/iiif-canvas-panel) is the web
+  component. Its distribution includes vault and the various web components.
+- [IIIF Image API](https://github.com/atlas-viewer/iiif-image-api) is a utility
+  library for working with IIIF Image resources
 
 <Tabs>
 
 <Tab label="Script tag" value="script-tag" default>
     
-The web components (canvas-panel and image-service) are bundled in one script: 
+The web components (canvas-panel and image-service) are bundled in one script:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest"></script>
 
 <canvas-panel
   manifest-id="https://digirati-co-uk.github.io/wunder.json"
-  canvas-id="https://digirati-co-uk.github.io/wunder/canvases/0">
+  canvas-id="https://digirati-co-uk.github.io/wunder/canvases/0"
+>
 </canvas-panel>
 ```
 
-This also gives you access to [Vault](./api-reference/vault), for doing things programmatically:
+This also gives you access to [Vault](./api-reference/vault), for doing things
+programmatically:
 
 ```html {7}
 <canvas-panel id="cp"></canvas-panel>
 
 <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest"></script>
-<script>  
-    const cp = document.getElementById("cp");
-    const manifestUrl = "https://digirati-co-uk.github.io/wunder.json";
-    cp.vault.load(manifestUrl).then((manifest) => console.log(manifest.items.length));
-</script>  
+<script>
+  const cp = document.getElementById("cp");
+  const manifestUrl = "https://digirati-co-uk.github.io/wunder.json";
+  cp.vault
+    .load(manifestUrl)
+    .then((manifest) => console.log(manifest.items.length));
+</script>
 ```
 
 You can use Vault independently of the Canvas Panel web component:
 
 ```html {4-5}
-<script src="https://cdn.jsdelivr.net/npm/@iiif/vault@latest/dist/index.umd.js"></script>
-<script>  
-    const manifestUrl = "https://digirati-co-uk.github.io/wunder.json";
-    const vault = new IIIFVault.Vault();
-    vault.load(manifestUrl).then((manifest) => console.log(manifest.items.length));
-</script>  
+<script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
+<script>
+  const manifestUrl = "https://digirati-co-uk.github.io/wunder.json";
+  const vault = new IIIFHelpers.Vault();
+  vault
+    .load(manifestUrl)
+    .then((manifest) => console.log(manifest.items.length));
+</script>
 ```
 
 ([Read more about Vault](./api-reference/vault))
-  
+
 </Tab>
 
 <Tab label="NPM / Yarn" value="npm-yarn">
@@ -83,33 +96,37 @@ yarn add @digirati/canvas-panel-web-components
 ```
 
 and then import in your script:
+
 ```js
-import '@digirati/canvas-panel-web-components';
+import "@digirati/canvas-panel-web-components";
 ```
 
 #### And the supporting libraries for Vault + Helpers:
 
-
 NPM Projects:
+
 ```bash
-npm i @iiif/vault @iiif/vault-helpers
+npm i @iiif/helpers
 ```
 
 Yarn projects:
+
 ```bash
-yarn add @iiif/vault @iiif/vault-helpers
+yarn add @iiif/helpers
 ```
 
 and then import:
+
 ```js
-import { Vault } from '@iiif/vault';
-```
-or with RequireJS / Node:
-```js
-const { Vault }  = require('@iiif/vault');
+import { Vault } from "@iiif/helpers/vault";
 ```
 
-  
+or with RequireJS / Node:
+
+```js
+const { Vault } = require("@iiif/helpers/vault");
+```
+
 </Tab>
   
 </Tabs>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -34,12 +34,10 @@ module.exports = {
   ],
   scripts: [
     // 'https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest',
-    "https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.56",
+    // "https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@1.0.56",
     // 'https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js'
   ],
-  // clientModules: [
-  //   require.resolve('./packages/canvas-panel/dist/bundle.js'),
-  // ],
+  clientModules: [require.resolve("./packages/canvas-panel/dist/bundle.js")],
   customFields: {
     canvasPanelVersion:
       isPr && !process.env.CANVAS_PANEL_VERSION

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^17"
   },
   "dependencies": {
-    "@atlas-viewer/atlas": "1.6.6",
+    "@atlas-viewer/atlas": "^2.0.5",
     "@cmfcmf/docusaurus-search-local": "^0.11.0",
     "@codesandbox/sandpack-react": "^0.14.2",
     "@docusaurus/core": "2.0.0-beta.22",

--- a/packages/canvas-panel/codex.html
+++ b/packages/canvas-panel/codex.html
@@ -1,0 +1,93 @@
+<html>
+<head>
+    <meta charset='UTF-8'>
+    <meta name='viewport'
+          content='width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0'>
+    <meta http-equiv='X-UA-Compatible' content='ie=edge'>
+    <title>Document</title>
+    <style>
+        canvas-panel::part(my-class) {
+            background: rgba(50, 0, 200, 0.4);
+        }
+
+        canvas-panel::part(my-link-class) {
+            border: 2px solid lightgreen;
+        }
+
+        canvas-panel::part(text-line-segment)::selection {
+            fill: #fff;
+            background: blue;
+        }
+
+        html {
+            height: 200vh;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+        }
+    </style>
+</head>
+<body>
+<script type='module' src='./src/index.ts'></script>
+
+
+<sequence-panel
+        id='sequence'
+        text-enabled='false'
+        text-selection-enabled='false'
+        manifest-id='https://dfc-django-backend.getty.digirati.io/iiif/iiif/manifest/9c45d6f2-8cba-4e49-a205-f86203c67d82/'
+        margin='30'
+        height="900"
+></sequence-panel>
+
+<div style="display: flex">
+    <div style="flex: 1">
+        <image-service src="https://media.getty.edu/iiif/image/d915e1a9-8dab-49de-8be1-c29b2228e0bf" image-width="5537" image-height="7630"></image-service>
+    </div>
+    <div style="flex: 1">
+        <image-service src="https://media.getty.edu/iiif/image/2efd825f-41fe-4f93-b928-f25644c67b23" image-width="5262" image-height="7488"></image-service>
+    </div>
+    <div style="flex: 1">
+        <image-service src="https://media.getty.edu/iiif/image/90049c0d-bfd0-4ee9-8b32-70e45597bf5c" image-width="5209" image-height="7397"></image-service>
+    </div>
+    <div style="flex: 1">
+        <image-service src="https://media.getty.edu/iiif/image/f21dbf12-d3b0-4019-814a-61962df5ca77"></image-service>
+    </div>
+</div>
+
+<button id='prev'>prev</button>
+<button id='next'>next</button>
+
+<script type="module">
+    const seq = document.getElementById('sequence');
+    const next = document.getElementById('next');
+    const prev = document.getElementById('prev');
+
+    seq.addEventListener('sequence', () => {
+        console.log('sequence', seq.sequence);
+    })
+
+    next.addEventListener('click', () => {
+        seq.sequence.nextCanvas();
+    })
+    prev.addEventListener('click', () => {
+        seq.sequence.previousCanvas();
+    })
+
+    seq.addEventListener('sequence-change', (e) => {
+        if (e.detail.index === 0) {
+            prev.setAttribute('disabled', 'true');
+        } else {
+            prev.removeAttribute('disabled');
+        }
+        if (e.detail.total - 1 <= e.detail.index) {
+            next.setAttribute('disabled', 'true');
+        } else {
+            next.removeAttribute('disabled');
+        }
+    })
+</script>
+
+</body>
+</html>

--- a/packages/canvas-panel/demo.html
+++ b/packages/canvas-panel/demo.html
@@ -9,16 +9,16 @@
 </head>
 <body>
 <canvas-panel
-  canvas-id="https://digirati-co-uk.github.io/wunder/canvases/0"
-  manifest-id="https://digirati-co-uk.github.io/wunder.json"
->
-</canvas-panel>
+  canvas-id="https://iiif-dev.slf.digirati.io/presentation/632173/canvases/632173_0_0010"
+  manifest-id="https://iiif-dev.slf.digirati.io/presentation/632173"
+  text-enabled="true"
+/>
 
-<div style="width:200px">
-  <canvas-panel
-    preset="responsive"
-    iiif-content="JTdCJTIyaWQlMjIlM0ElMjJodHRwcyUzQSUyRiUyRmRpZ2lyYXRpLWNvLXVrLmdpdGh1Yi5pbyUyRnd1bmRlciUyRmNhbnZhc2VzJTJGMTAlMjN4eXdoJTNEMzI5JTJDMjM1NyUyQzQzNSUyQzQxNSUyMiUyQyUyMnR5cGUlMjIlM0ElMjJDYW52YXMlMjIlMkMlMjJwYXJ0T2YlMjIlM0ElNUIlN0IlMjJpZCUyMiUzQSUyMmh0dHBzJTNBJTJGJTJGZGlnaXJhdGktY28tdWsuZ2l0aHViLmlvJTJGd3VuZGVyLmpzb24lMjIlMkMlMjJ0eXBlJTIyJTNBJTIyTWFuaWZlc3QlMjIlN0QlNUQlN0Q"
-  />
-</div>
+<!--<div style="width:200px">-->
+<!--  <canvas-panel-->
+<!--    preset="responsive"-->
+<!--    iiif-content="JTdCJTIyaWQlMjIlM0ElMjJodHRwcyUzQSUyRiUyRmRpZ2lyYXRpLWNvLXVrLmdpdGh1Yi5pbyUyRnd1bmRlciUyRmNhbnZhc2VzJTJGMTAlMjN4eXdoJTNEMzI5JTJDMjM1NyUyQzQzNSUyQzQxNSUyMiUyQyUyMnR5cGUlMjIlM0ElMjJDYW52YXMlMjIlMkMlMjJwYXJ0T2YlMjIlM0ElNUIlN0IlMjJpZCUyMiUzQSUyMmh0dHBzJTNBJTJGJTJGZGlnaXJhdGktY28tdWsuZ2l0aHViLmlvJTJGd3VuZGVyLmpzb24lMjIlMkMlMjJ0eXBlJTIyJTNBJTIyTWFuaWZlc3QlMjIlN0QlNUQlN0Q"-->
+<!--  />-->
+<!--</div>-->
 </body>
 </html>

--- a/packages/canvas-panel/demos/content-state/index.html
+++ b/packages/canvas-panel/demos/content-state/index.html
@@ -1,412 +1,443 @@
-
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+      integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" />
+    <link rel="stylesheet" href="./cs.css" />
+    <title>Content State Selector</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
-  <link rel="stylesheet" href="./cs.css">
-  <title>Content State Selector</title>
-</head>
+  <body>
+    <div class="meta">
+      <div class="container">
+        <h2>IIIF Picker and Content State Selector</h2>
 
-<body>
+        <div class="row">
+          <div class="col-md-auto p-2 ps-3">
+            <p>How far are we wanting the user to go?</p>
+            <p>This would be determined by whatever launches this widget - what do we want back?</p>
+            <div class="btn-group" role="group" aria-label="Modes">
+              <input
+                type="radio"
+                class="btn-check btn-mode"
+                name="btnMode"
+                id="modeManifest"
+                value="manifest"
+                autocomplete="off"
+                checked
+              />
+              <label class="btn btn-outline-primary" for="modeManifest">Manifest</label>
 
-<div class="meta">
+              <input
+                type="radio"
+                class="btn-check btn-mode"
+                name="btnMode"
+                id="modeCanvas"
+                value="canvas"
+                autocomplete="off"
+              />
+              <label class="btn btn-outline-primary" for="modeCanvas">Canvas</label>
 
-  <div class="container">
-    <h2>IIIF Picker and Content State Selector</h2>
-
-    <div class="row">
-      <div class="col-md-auto p-2 ps-3">
-        <p>How far are we wanting the user to go?</p>
-        <p>This would be determined by whatever launches this widget - what do we want back?</p>
-        <div class="btn-group" role="group" aria-label="Modes">
-          <input type="radio" class="btn-check btn-mode" name="btnMode" id="modeManifest" value="manifest" autocomplete="off" checked>
-          <label class="btn btn-outline-primary" for="modeManifest">Manifest</label>
-
-          <input type="radio" class="btn-check btn-mode" name="btnMode" id="modeCanvas" value="canvas" autocomplete="off">
-          <label class="btn btn-outline-primary" for="modeCanvas">Canvas</label>
-
-          <input type="radio" class="btn-check btn-mode" name="btnMode" id="modeRegion" value="region" autocomplete="off">
-          <label class="btn btn-outline-primary" for="modeRegion">Canvas region</label>
+              <input
+                type="radio"
+                class="btn-check btn-mode"
+                name="btnMode"
+                id="modeRegion"
+                value="region"
+                autocomplete="off"
+              />
+              <label class="btn btn-outline-primary" for="modeRegion">Canvas region</label>
+            </div>
+          </div>
         </div>
       </div>
 
+      <div class="container">
+        <form>
+          <div class="input-group">
+            <input
+              type="text"
+              id="mediaUrl"
+              class="form-control"
+              placeholder="Start browsing from URL of any IIIF Collection or Manifest"
+              aria-label="URL of Media"
+              aria-describedby="mediaHelp"
+            />
+            <button
+              type="button"
+              class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
+              <span class="visually-hidden">Toggle Dropdown</span>
+            </button>
+            <ul class="dropdown-menu" id="recentResources">
+              <li>
+                <h6 class="dropdown-header">Recent manifests and collections</h6>
+              </li>
+              <li><a class="dropdown-item" href="#">Internal demo of different bodies</a></li>
+              <li><a class="dropdown-item" href="#">Internal demo of Textual bodies</a></li>
+              <li><a class="dropdown-item" href="#">External Annotation Page</a></li>
+            </ul>
+            <div class="input-group-append">
+              <button class="btn btn-outline-secondary" id="refreshUrl" type="button">⟳</button>
+            </div>
+          </div>
+          <div class="grid-container" id="treeHolder">
+            <div class="grid-item grid-button">
+              <button class="btn btn-primary btn-sm expander" type="button" id="treeExpander">
+                <i class="bi bi-chevron-expand"></i>
+              </button>
+            </div>
+            <div class="grid-item grid-heading">
+              <h6 id="selectedResourceLabel"></h6>
+            </div>
+            <div class="grid-item grid-content" id="treeHolderInner">
+              <ul id="treeTop"></ul>
+            </div>
+          </div>
+          <div class="grid-container" id="thumbnailsContainer">
+            <div class="grid-item grid-button">
+              <button class="btn btn-primary btn-sm expander" type="button" id="thumbsExpander">
+                <i class="bi bi-chevron-expand"></i>
+              </button>
+            </div>
+            <div class="grid-item grid-heading">
+              <h6 id="selectedManifestLabel"></h6>
+            </div>
+            <div class="grid-item grid-content">
+              <div id="thumbnails"></div>
+            </div>
+          </div>
+          <div class="grid-container" id="canvas">
+            <div class="grid-item grid-button">
+              <button class="btn btn-primary btn-sm expander" type="button" id="canvasExpander">
+                <i class="bi bi-chevron-expand"></i>
+              </button>
+            </div>
+            <div class="grid-item grid-heading">
+              <div class="form-check form-switch" style="margin-top: 0.9rem">
+                <input class="form-check-input" type="checkbox" role="switch" id="canvasSelectionMode" />
+                <label class="form-check-label" for="canvasSelectionMode">Enable region selection</label>
+              </div>
+              <!-- <h6 id="selectedCanvasLabel"></h6> -->
+            </div>
+            <div class="grid-item grid-content" id="cpHolder">
+              <canvas-panel id="cp" height="500"></canvas-panel>
+            </div>
+          </div>
+
+          <div id="preview" style="width: 300px"></div>
+          <pre id="selection"></pre>
+
+          <!--      <button type="submit" class="btn btn-primary">Select</button>-->
+          <!--      <button type="submit" class="btn btn-primary">Cancel</button>-->
+        </form>
+      </div>
     </div>
-  </div>
 
-  <div class="container">
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+      crossorigin="anonymous"
+    ></script>
+    <script type="module">
+      import '../../src';
+      import * as VaultHelpers from '@iiif/helpers';
 
-    <form>
-      <div class="input-group">
-        <input type="text" id="mediaUrl" class="form-control" placeholder="Start browsing from URL of any IIIF Collection or Manifest" aria-label="URL of Media" aria-describedby="mediaHelp">
-        <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-          <span class="visually-hidden">Toggle Dropdown</span>
-        </button>
-        <ul class="dropdown-menu" id="recentResources">
-          <li>
-            <h6 class="dropdown-header">Recent manifests and collections</h6>
-          </li>
-          <li><a class="dropdown-item" href="#">Internal demo of different bodies</a></li>
-          <li><a class="dropdown-item" href="#">Internal demo of Textual bodies</a></li>
-          <li><a class="dropdown-item" href="#">External Annotation Page</a></li>
-        </ul>
-        <div class="input-group-append">
-          <button class="btn btn-outline-secondary" id="refreshUrl" type="button">⟳</button>
-        </div>
-      </div>
-      <div class="grid-container" id="treeHolder">
-        <div class="grid-item grid-button">
-          <button class="btn btn-primary btn-sm expander" type="button" id="treeExpander">
-            <i class="bi bi-chevron-expand"></i>
-          </button>
-        </div>
-        <div class="grid-item grid-heading">
-          <h6 id="selectedResourceLabel"></h6>
-        </div>
-        <div class="grid-item grid-content" id="treeHolderInner">
-          <ul id="treeTop"></ul>
-        </div>
-      </div>
-      <div class="grid-container" id="thumbnailsContainer">
-        <div class="grid-item grid-button">
-          <button class="btn btn-primary btn-sm expander" type="button" id="thumbsExpander">
-            <i class="bi bi-chevron-expand"></i>
-          </button>
-        </div>
-        <div class="grid-item grid-heading">
-          <h6 id="selectedManifestLabel"></h6>
-        </div>
-        <div class="grid-item grid-content">
-          <div id="thumbnails">
+      const recentStarts = [
+        {
+          id: 'https://iiif.wellcomecollection.org/presentation/b15701360',
+          type: 'Manifest',
+          label: {
+            en: ['Welfare foods service entitlement book / Ministry of Food.'],
+          },
+        },
+        {
+          id: 'https://tomcrane.github.io/scratch/contentstate/wellcomefoods.json',
+          type: 'Collection',
+          label: { en: ['Some foodstuffs from Wellcome'] },
+        },
+        {
+          id: 'https://iiif.bodleian.ox.ac.uk/iiif/collection/top',
+          type: 'Collection',
+          label: { en: ['Bodleian Library, Oxford'] },
+          summary: { en: ['Top-level collection of IIIF manifests from the Bodleian Library and Oxford Colleges'] },
+        },
+        {
+          id: 'https://iiif.wellcomecollection.org/presentation/b28974141',
+          type: 'Manifest',
+          label: {
+            en: [
+              "The floral emblems of purity are the white lily & the star of Bethlehem : for purity of blood use Frazer's Sulphur Tablets : test them free of charge.",
+            ],
+          },
+          summary: {
+            en: [
+              "<p>Leaflet issued by Frazer's Tablets, Limited advertising Frazer's Sulphur Tablets and Frazer's Sulphur Soap, used to treat ulcers, tuberculosis, and scurvy.</p>",
+            ],
+          },
+          thumbnail: [
+            {
+              id: 'https://iiif.wellcomecollection.org/thumbs/b28974141_0001.jp2/full/66,100/0/default.jpg',
+              type: 'Image',
+              width: 66,
+              height: 100,
+              service: [
+                {
+                  '@id': 'https://iiif.wellcomecollection.org/thumbs/b28974141_0001.jp2',
+                  '@type': 'ImageService2',
+                  profile: 'http://iiif.io/api/image/2/level0.json',
+                  width: 680,
+                  height: 1024,
+                  sizes: [
+                    { width: 66, height: 100 },
+                    { width: 133, height: 200 },
+                    { width: 265, height: 400 },
+                    { width: 680, height: 1024 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'https://iiif.wellcomecollection.org/presentation/b19318388',
+          type: 'Manifest',
+          label: { en: ['Receipt-Book, Italian: 16th century'] },
+          summary: {
+            en: [
+              "Collection of medical receipts: mainly in Italian, the rest in Latin. Written in a small semi-current humanistic hand with a few later additions. On the verso of the fifth leaf is scribbled the name 'Alsinoro Marco 1648'.",
+            ],
+          },
+          thumbnail: [
+            {
+              id: 'https://iiif.wellcomecollection.org/thumbs/b19318388_MS_650_0001.JP2/full/74,100/0/default.jpg',
+              type: 'Image',
+              width: 74,
+              height: 100,
+              service: [
+                {
+                  '@id': 'https://iiif.wellcomecollection.org/thumbs/b19318388_MS_650_0001.JP2',
+                  '@type': 'ImageService2',
+                  profile: 'http://iiif.io/api/image/2/level0.json',
+                  width: 759,
+                  height: 1024,
+                  sizes: [
+                    { width: 74, height: 100 },
+                    { width: 148, height: 200 },
+                    { width: 296, height: 400 },
+                    { width: 759, height: 1024 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'https://iiif.wellcomecollection.org/presentation/b19974760',
+          type: 'Collection',
+          label: { en: ['The Chemist and Druggist'] },
+        },
+        {
+          id: 'http://ryanfb.github.io/iiif-universe/iiif-universe.json',
+          type: 'Collection',
+          label: { en: ['IIIF Universe (danger!)'] },
+        },
+      ];
 
-          </div>
-        </div>
-      </div>
-      <div class="grid-container" id="canvas">
-        <div class="grid-item grid-button">
-          <button class="btn btn-primary btn-sm expander" type="button" id="canvasExpander">
-            <i class="bi bi-chevron-expand"></i>
-          </button>
-        </div>
-        <div class="grid-item grid-heading">
-          <div class="form-check form-switch" style="margin-top: 0.9rem">
-            <input class="form-check-input" type="checkbox" role="switch" id="canvasSelectionMode">
-            <label class="form-check-label" for="canvasSelectionMode">Enable region selection</label>
-          </div>
-          <!-- <h6 id="selectedCanvasLabel"></h6> -->
-        </div>
-        <div class="grid-item grid-content" id="cpHolder">
-          <canvas-panel id="cp" height="500"></canvas-panel>
-        </div>
-
-
-      </div>
-
-      <div id="preview" style="width: 300px;">
-
-      </div>
-      <pre id="selection"></pre>
-
-
-<!--      <button type="submit" class="btn btn-primary">Select</button>-->
-<!--      <button type="submit" class="btn btn-primary">Cancel</button>-->
-    </form>
-  </div>
-</div>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
-<script type="module">
-  import '../../src';
-  import * as VaultHelpers from '@iiif/vault-helpers';
-
-  const recentStarts = [{
-    "id": "https://iiif.wellcomecollection.org/presentation/b15701360",
-    "type": "Manifest",
-    "label": {
-      "en": [
-        "Welfare foods service entitlement book / Ministry of Food."
-      ]
-    }
-  },
-    {
-      "id": "https://tomcrane.github.io/scratch/contentstate/wellcomefoods.json",
-      "type": "Collection",
-      "label": { "en": ["Some foodstuffs from Wellcome"] }
-    },
-    {
-      "id": "https://iiif.bodleian.ox.ac.uk/iiif/collection/top",
-      "type": "Collection",
-      "label": { "en": ["Bodleian Library, Oxford"] },
-      "summary": { "en": ["Top-level collection of IIIF manifests from the Bodleian Library and Oxford Colleges"] }
-    },
-    {
-      "id": "https://iiif.wellcomecollection.org/presentation/b28974141",
-      "type": "Manifest",
-      "label": {
-        "en": [
-          "The floral emblems of purity are the white lily & the star of Bethlehem : for purity of blood use Frazer's Sulphur Tablets : test them free of charge."
-        ]
-      },
-      "summary": {
-        "en": [
-          "<p>Leaflet issued by Frazer's Tablets, Limited advertising Frazer's Sulphur Tablets and Frazer's Sulphur Soap, used to treat ulcers, tuberculosis, and scurvy.</p>"
-        ]
-      },
-      "thumbnail": [{
-        "id": "https://iiif.wellcomecollection.org/thumbs/b28974141_0001.jp2/full/66,100/0/default.jpg",
-        "type": "Image",
-        "width": 66,
-        "height": 100,
-        "service": [{
-          "@id": "https://iiif.wellcomecollection.org/thumbs/b28974141_0001.jp2",
-          "@type": "ImageService2",
-          "profile": "http://iiif.io/api/image/2/level0.json",
-          "width": 680,
-          "height": 1024,
-          "sizes": [
-            { "width": 66, "height": 100 },
-            { "width": 133, "height": 200 },
-            { "width": 265, "height": 400 },
-            { "width": 680, "height": 1024 }
-          ]
-        }]
-      }],
-    },
-    {
-      "id": "https://iiif.wellcomecollection.org/presentation/b19318388",
-      "type": "Manifest",
-      "label": { "en": ["Receipt-Book, Italian: 16th century"] },
-      "summary": {
-        "en": [
-          "Collection of medical receipts: mainly in Italian, the rest in Latin. Written in a small semi-current humanistic hand with a few later additions. On the verso of the fifth leaf is scribbled the name 'Alsinoro Marco 1648'."
-        ]
-      },
-      "thumbnail": [{
-        "id": "https://iiif.wellcomecollection.org/thumbs/b19318388_MS_650_0001.JP2/full/74,100/0/default.jpg",
-        "type": "Image",
-        "width": 74,
-        "height": 100,
-        "service": [{
-          "@id": "https://iiif.wellcomecollection.org/thumbs/b19318388_MS_650_0001.JP2",
-          "@type": "ImageService2",
-          "profile": "http://iiif.io/api/image/2/level0.json",
-          "width": 759,
-          "height": 1024,
-          "sizes": [
-            { "width": 74, "height": 100 },
-            { "width": 148, "height": 200 },
-            { "width": 296, "height": 400 },
-            { "width": 759, "height": 1024 }
-          ]
-        }]
-      }]
-    },
-    {
-      "id": "https://iiif.wellcomecollection.org/presentation/b19974760",
-      "type": "Collection",
-      "label": { "en": ["The Chemist and Druggist"] }
-    },
-    {
-      "id": "http://ryanfb.github.io/iiif-universe/iiif-universe.json",
-      "type": "Collection",
-      "label": { "en": ["IIIF Universe (danger!)"] }
-    }
-  ];
-
-  function $(s) {
-    if (s.startsWith("#")) {
-      return document.getElementById(s.substring(1));
-    } else {
-      return document.querySelectorAll(s);
-    }
-  }
-
-  const cp = $("#cp");
-  const vault = cp.vault;
-
-  console.log(cp.vault);
-
-  const thumbHelper = VaultHelpers.createThumbnailHelper(cp.vault);
-  const collectionPath = [];
-  let currentManifestId = null;
-  let currentCanvasId = null;
-  let currentContentStateCapture = null;
-
-
-  clear();
-  setRecents();
-
-  $("#mediaUrl").addEventListener("change", loadIIIF);
-  $("#refreshUrl").addEventListener("click", loadIIIF);
-
-  function clear() {
-    $("#treeHolder").style.display = "none";
-    $("#thumbnailsContainer").style.display = "none";
-    $("#canvas").style.display = "none";
-    $("#selection").innerText = "";
-  }
-
-  function truncate(s) {
-    if (s && s.length > 85) {
-      return s.substring(0, 82) + "...";
-    }
-    return s;
-  }
-
-  function setRecents() {
-    const recents = $("#recentResources");
-    recents.innerHTML = "";
-    const header = document.createElement("li");
-    header.innerHTML = '<h6 class="dropdown-header">Recent manifests and collections</h6>';
-    recents.append(header);
-    for (let resource of recentStarts) {
-      const li = document.createElement("li");
-      const a = document.createElement("a");
-      a.className = "dropdown-item";
-      a.href = resource.id;
-      a.innerHTML = getLabelledIcon(resource, resource.label.en[0]); // this is not normally safe!
-      a.addEventListener("click", function(e) {
-        e.preventDefault();
-        $("#mediaUrl").value = this.href;
-        loadIIIF();
-      });
-      li.append(a);
-      recents.append(li);
-    }
-  }
-
-  function getLabelledIcon(resource, label) {
-    return '<i class="' + getIconClass(resource) + '"></i> ' + truncate(label);
-  }
-
-  function getIconClass(resource) {
-    return resource.type == "Collection" ? "bi bi-folder" : "bi bi-file-earmark-richtext";
-  }
-
-  async function loadIIIF() {
-    let url = $("#mediaUrl").value.trim();
-    clear();
-    if (url) {
-      const iiifResource = await vault.load(url);
-      if (iiifResource.type == "Manifest") {
-        setManifest(iiifResource);
-      } else if (iiifResource.type == "Collection") {
-        startTree(iiifResource);
-      } else if (iiifResource.type == "Canvas") {
-        showCanvasById(iiifResource.id);
+      function $(s) {
+        if (s.startsWith('#')) {
+          return document.getElementById(s.substring(1));
+        } else {
+          return document.querySelectorAll(s);
+        }
       }
-    }
-  }
 
-  async function setManifest(manifest) {
-    currentManifestId = manifest.id;
-    const thumbDiv = $("#thumbnails");
-    $("#thumbnailsContainer").style.display = "grid";
-    thumbDiv.innerHTML = "";
-    $("#selectedManifestLabel").innerText = getLabel(manifest, manifest);
-    for (let canvasRef of manifest.items) {
-      const canvas = vault.get(canvasRef);
-      const img = document.createElement("img");
-      const cvThumb = await thumbHelper.getBestThumbnailAtSize(canvas, { maxWidth: 100 });
-      // hack to fix thumbnail bug - not a very safe hack but anyway...
-      let thumbUrl = cvThumb.best.id;
-      thumbUrl = thumbUrl.replace("/99,", "/100,");
-      thumbUrl = thumbUrl.replace(",99/", ",100/");
-      img.src = thumbUrl;
-      const canvasId = canvas.id;
-      img.addEventListener("click", () => showCanvasById(canvasId));
-      thumbDiv.append(img);
-    }
-  }
+      const cp = $('#cp');
+      const vault = cp.vault;
 
-  async function startTree(collection) {
-    const top = $("#treeHolder");
-    const inner = $("#treeHolderInner");
-    const lists = inner.getElementsByTagName("ul");
-    if (lists.length > 0) {
-      lists[0].remove();
-    }
-    top.style.display = "grid";
-    const vColl = await vault.load(collection);
-    $("#selectedResourceLabel").innerText = getLabel(collection, vColl);
-    await renderInto(inner, vColl);
-  }
+      console.log(cp.vault);
 
+      const thumbHelper = VaultHelpers.createThumbnailHelper(cp.vault);
+      const collectionPath = [];
+      let currentManifestId = null;
+      let currentCanvasId = null;
+      let currentContentStateCapture = null;
 
-  function getLabel(res1, res2) {
-    return VaultHelpers.getValue(res1.label) || VaultHelpers.getValue(res2.label);
-  }
+      clear();
+      setRecents();
 
-  async function renderInto(element, collection) {
-    const ul = document.createElement("ul");
-    ul.className = "list-group";
-    ul.classList.add("list-group-flush");
-    for (let item of collection.items) {
-      const vItem = vault.get(item);
-      const label = getLabel(vItem, item);
-      const li = document.createElement("li");
-      li.className = "list-group-item";
-      const a = document.createElement("a");
-      a.href = item.id;
-      a.setAttribute("data-type", item.type);
-      a.innerHTML = getLabelledIcon(item, label)
-      li.append(a);
-      ul.append(li);
-      a.addEventListener("click", async function(e) {
-        e.preventDefault();
-        if (this.getAttribute("data-type") == "Manifest") {
-          const manifest = await vault.load(this.href);
-          setManifest(manifest);
-        } else if (this.getAttribute("data-type") == "Collection") {
-          const childUls = this.parentElement.getElementsByTagName("ul");
-          if (childUls.length > 0) {
-            childUls[0].remove();
-          } else {
-            const lip = this.parentElement;
-            const subCollection = await vault.load(this.href);
-            renderInto(lip, subCollection);
+      $('#mediaUrl').addEventListener('change', loadIIIF);
+      $('#refreshUrl').addEventListener('click', loadIIIF);
+
+      function clear() {
+        $('#treeHolder').style.display = 'none';
+        $('#thumbnailsContainer').style.display = 'none';
+        $('#canvas').style.display = 'none';
+        $('#selection').innerText = '';
+      }
+
+      function truncate(s) {
+        if (s && s.length > 85) {
+          return s.substring(0, 82) + '...';
+        }
+        return s;
+      }
+
+      function setRecents() {
+        const recents = $('#recentResources');
+        recents.innerHTML = '';
+        const header = document.createElement('li');
+        header.innerHTML = '<h6 class="dropdown-header">Recent manifests and collections</h6>';
+        recents.append(header);
+        for (let resource of recentStarts) {
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.className = 'dropdown-item';
+          a.href = resource.id;
+          a.innerHTML = getLabelledIcon(resource, resource.label.en[0]); // this is not normally safe!
+          a.addEventListener('click', function (e) {
+            e.preventDefault();
+            $('#mediaUrl').value = this.href;
+            loadIIIF();
+          });
+          li.append(a);
+          recents.append(li);
+        }
+      }
+
+      function getLabelledIcon(resource, label) {
+        return '<i class="' + getIconClass(resource) + '"></i> ' + truncate(label);
+      }
+
+      function getIconClass(resource) {
+        return resource.type == 'Collection' ? 'bi bi-folder' : 'bi bi-file-earmark-richtext';
+      }
+
+      async function loadIIIF() {
+        let url = $('#mediaUrl').value.trim();
+        clear();
+        if (url) {
+          const iiifResource = await vault.load(url);
+          if (iiifResource.type == 'Manifest') {
+            setManifest(iiifResource);
+          } else if (iiifResource.type == 'Collection') {
+            startTree(iiifResource);
+          } else if (iiifResource.type == 'Canvas') {
+            showCanvasById(iiifResource.id);
           }
         }
+      }
+
+      async function setManifest(manifest) {
+        currentManifestId = manifest.id;
+        const thumbDiv = $('#thumbnails');
+        $('#thumbnailsContainer').style.display = 'grid';
+        thumbDiv.innerHTML = '';
+        $('#selectedManifestLabel').innerText = getLabel(manifest, manifest);
+        for (let canvasRef of manifest.items) {
+          const canvas = vault.get(canvasRef);
+          const img = document.createElement('img');
+          const cvThumb = await thumbHelper.getBestThumbnailAtSize(canvas, { maxWidth: 100 });
+          // hack to fix thumbnail bug - not a very safe hack but anyway...
+          let thumbUrl = cvThumb.best.id;
+          thumbUrl = thumbUrl.replace('/99,', '/100,');
+          thumbUrl = thumbUrl.replace(',99/', ',100/');
+          img.src = thumbUrl;
+          const canvasId = canvas.id;
+          img.addEventListener('click', () => showCanvasById(canvasId));
+          thumbDiv.append(img);
+        }
+      }
+
+      async function startTree(collection) {
+        const top = $('#treeHolder');
+        const inner = $('#treeHolderInner');
+        const lists = inner.getElementsByTagName('ul');
+        if (lists.length > 0) {
+          lists[0].remove();
+        }
+        top.style.display = 'grid';
+        const vColl = await vault.load(collection);
+        $('#selectedResourceLabel').innerText = getLabel(collection, vColl);
+        await renderInto(inner, vColl);
+      }
+
+      function getLabel(res1, res2) {
+        return VaultHelpers.getValue(res1.label) || VaultHelpers.getValue(res2.label);
+      }
+
+      async function renderInto(element, collection) {
+        const ul = document.createElement('ul');
+        ul.className = 'list-group';
+        ul.classList.add('list-group-flush');
+        for (let item of collection.items) {
+          const vItem = vault.get(item);
+          const label = getLabel(vItem, item);
+          const li = document.createElement('li');
+          li.className = 'list-group-item';
+          const a = document.createElement('a');
+          a.href = item.id;
+          a.setAttribute('data-type', item.type);
+          a.innerHTML = getLabelledIcon(item, label);
+          li.append(a);
+          ul.append(li);
+          a.addEventListener('click', async function (e) {
+            e.preventDefault();
+            if (this.getAttribute('data-type') == 'Manifest') {
+              const manifest = await vault.load(this.href);
+              setManifest(manifest);
+            } else if (this.getAttribute('data-type') == 'Collection') {
+              const childUls = this.parentElement.getElementsByTagName('ul');
+              if (childUls.length > 0) {
+                childUls[0].remove();
+              } else {
+                const lip = this.parentElement;
+                const subCollection = await vault.load(this.href);
+                renderInto(lip, subCollection);
+              }
+            }
+          });
+        }
+        element.append(ul);
+      }
+
+      function showCanvasById(canvasId) {
+        $('#canvasSelectionMode').checked = false;
+        cp.disableContentStateSelection();
+        $('#canvas').style.display = 'grid';
+        cp.setCanvas(canvasId);
+        currentCanvasId = canvasId;
+      }
+
+      $('#treeExpander').addEventListener('click', () => $('#treeHolderInner').classList.toggle('expanded'));
+
+      let setLast;
+      $('#canvasSelectionMode').addEventListener('change', (e) => {
+        if (e.target.checked) {
+          cp.enableContentStateSelection((ev) => {
+            $('#selection').innerText = JSON.stringify(ev, null, 2);
+            // <canvas-panel id="preview" preset="static" height="500"></canvas-panel>
+            const preview = document.createElement('canvas-panel');
+            preview.setAttribute('preset', 'responsive');
+            preview.setAttribute('height', '200');
+            preview.setAttribute('iiif-content', ev.encodedContentState);
+            $('#preview').innerHTML = '';
+            $('#preview').appendChild(preview);
+          });
+        } else {
+          cp.disableContentStateSelection();
+        }
       });
-    }
-    element.append(ul);
-
-  }
-
-  function showCanvasById(canvasId) {
-    $("#canvasSelectionMode").checked = false;
-    cp.disableContentStateSelection();
-    $("#canvas").style.display = "grid";
-    cp.setCanvas(canvasId);
-    currentCanvasId = canvasId;
-  }
-
-  $("#treeExpander").addEventListener("click", () => $("#treeHolderInner").classList.toggle("expanded"));
-
-
-  let setLast
-  $('#canvasSelectionMode').addEventListener('change', e => {
-    if (e.target.checked) {
-      cp.enableContentStateSelection(ev => {
-        $('#selection').innerText = JSON.stringify(ev, null, 2);
-        // <canvas-panel id="preview" preset="static" height="500"></canvas-panel>
-        const preview = document.createElement('canvas-panel');
-        preview.setAttribute('preset', 'responsive');
-        preview.setAttribute('height', '200');
-        preview.setAttribute('iiif-content', ev.encodedContentState);
-        $('#preview').innerHTML = '';
-        $('#preview').appendChild(preview);
-      })
-    } else {
-      cp.disableContentStateSelection();
-    }
-  })
-
-</script>
-</body>
-
+    </script>
+  </body>
 </html>

--- a/packages/canvas-panel/demos/simplest-viewer.html
+++ b/packages/canvas-panel/demos/simplest-viewer.html
@@ -1,81 +1,104 @@
-
 <html>
-<head>
+  <head>
     <title>Canvas Panel - simple</title>
     <style>
-        #manifest { width: 50vw; }
-        #th { width:12vw; border-right: 1px solid #999; margin: 5px; float:left; height:90%; overflow-y:scroll; }
-        #main { width:84vw; margin-top:30px; margin-left:10px; float:left; height:90%;}
-        .tc { display: inline-block; padding:5px; cursor: pointer; }
-        #cp { height:100% }
+      #manifest {
+        width: 50vw;
+      }
+      #th {
+        width: 12vw;
+        border-right: 1px solid #999;
+        margin: 5px;
+        float: left;
+        height: 90%;
+        overflow-y: scroll;
+      }
+      #main {
+        width: 84vw;
+        margin-top: 30px;
+        margin-left: 10px;
+        float: left;
+        height: 90%;
+      }
+      .tc {
+        display: inline-block;
+        padding: 5px;
+        cursor: pointer;
+      }
+      #cp {
+        height: 100%;
+      }
     </style>
     <script type="module" src="../src/index.ts"></script>
-</head>
-<body>
-<h1>A simple viewer using Canvas Panel</h1>
-<h2 id="manifestLabel"></h2>
-<div>
-    <input id="manifest" type="text" value="https://iiif.wellcomecollection.org/presentation/b18035723" />
-    <input id="go" type="button" value="Go" />
-</div>
-<div>
-    <div id="th"></div>
-    <div id="main">
-        <canvas-panel id="cp" height="600"></canvas-panel> <!--height="95%" -->
-        <p id="cvLabel"></p>
+  </head>
+  <body>
+    <h1>A simple viewer using Canvas Panel</h1>
+    <h2 id="manifestLabel"></h2>
+    <div>
+      <input id="manifest" type="text" value="https://iiif.wellcomecollection.org/presentation/b18035723" />
+      <input id="go" type="button" value="Go" />
     </div>
-</div>
-<script type="module">
-  import { createThumbnailHelper, getValue } from "@iiif/vault-helpers";
+    <div>
+      <div id="th"></div>
+      <div id="main">
+        <canvas-panel id="cp" height="600"></canvas-panel>
+        <!--height="95%" -->
+        <p id="cvLabel"></p>
+      </div>
+    </div>
+    <script type="module">
+      import { createThumbnailHelper, getValue } from '@iiif/helpers';
 
-  function $(id) { return document.getElementById(id); }
-  const cp = $("cp");
-  const thumbHelper = createThumbnailHelper(cp.vault);
-
-  async function loadManifest(){
-    const manifestUri = $("manifest").value;
-    if(manifestUri){
-      const manifest = await cp.vault.loadManifest(manifestUri);
-      $("manifestLabel").innerText = getValue(manifest.label);
-      let thumbsHtml = "";
-      for(const canvas of cp.vault.get(manifest.items)){
-        const label = getValue(canvas.label);
-        const cvThumb = await thumbHelper.getBestThumbnailAtSize(canvas, {maxWidth:100, maxHeight:200});
-        thumbsHtml += '<div class="tc">' + label + '<br/>';
-        thumbsHtml += '<img data-uri="' + canvas.id + '" data-label="' + label + '" src="' + cvThumb.best.id + '" />';
-        thumbsHtml += '</div>';
+      function $(id) {
+        return document.getElementById(id);
       }
-      $('th').innerHTML = thumbsHtml;
-      const thumbs = document.querySelectorAll('#th img');
-      for(const thumb of thumbs){
-        thumb.addEventListener('click', selectCanvas);
+      const cp = $('cp');
+      const thumbHelper = createThumbnailHelper(cp.vault);
+
+      async function loadManifest() {
+        const manifestUri = $('manifest').value;
+        if (manifestUri) {
+          const manifest = await cp.vault.loadManifest(manifestUri);
+          $('manifestLabel').innerText = getValue(manifest.label);
+          let thumbsHtml = '';
+          for (const canvas of cp.vault.get(manifest.items)) {
+            const label = getValue(canvas.label);
+            const cvThumb = await thumbHelper.getBestThumbnailAtSize(canvas, { maxWidth: 100, maxHeight: 200 });
+            thumbsHtml += '<div class="tc">' + label + '<br/>';
+            thumbsHtml +=
+              '<img data-uri="' + canvas.id + '" data-label="' + label + '" src="' + cvThumb.best.id + '" />';
+            thumbsHtml += '</div>';
+          }
+          $('th').innerHTML = thumbsHtml;
+          const thumbs = document.querySelectorAll('#th img');
+          for (const thumb of thumbs) {
+            thumb.addEventListener('click', selectCanvas);
+          }
+          thumbs[0].click();
+        }
       }
-      thumbs[0].click();
-    }
-  }
 
-  const state = {viewport: null};
+      const state = { viewport: null };
 
-  cp.withAtlas(viewport => {
-    state.viewport = viewport;
-  })
+      cp.withAtlas((viewport) => {
+        state.viewport = viewport;
+      });
 
-  cp.addEventListener('canvas-change', () => {
-    if (state.viewport) {
-      console.log(state.viewport.height);
-      console.log(state.viewport.world);
-    }
-  })
+      cp.addEventListener('canvas-change', () => {
+        if (state.viewport) {
+          console.log(state.viewport.height);
+          console.log(state.viewport.world);
+        }
+      });
 
-  $("go").addEventListener('click', loadManifest);
-  loadManifest();
+      $('go').addEventListener('click', loadManifest);
+      loadManifest();
 
-  function selectCanvas(){
-    const cvId = this.getAttribute("data-uri");
-    cp.setCanvas(cvId);
-    $("cvLabel").innerText = this.getAttribute("data-label");
-  }
-
-</script>
-</body>
+      function selectCanvas() {
+        const cvId = this.getAttribute('data-uri');
+        cp.setCanvas(cvId);
+        $('cvLabel').innerText = this.getAttribute('data-label');
+      }
+    </script>
+  </body>
 </html>

--- a/packages/canvas-panel/demos/vault-3a.html
+++ b/packages/canvas-panel/demos/vault-3a.html
@@ -1,93 +1,86 @@
-
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
+  <head>
     <title>Vault Example</title>
     <style>
-        .container {
-            display: grid;
-            grid-template-columns: auto auto;
-        }
+      .container {
+        display: grid;
+        grid-template-columns: auto auto;
+      }
 
-        img {
-            padding: 0.3em;
-        }
+      img {
+        padding: 0.3em;
+      }
     </style>
-</head>
+  </head>
 
-<body>
-<div class="container">
-    <div id="app"></div>
-    <pre id="data"></pre>
-</div>
-<script type="module">
-  import * as IIIFVault from '@iiif/vault';
-  import * as VaultHelpers from '@iiif/vault-helpers';
+  <body>
+    <div class="container">
+      <div id="app"></div>
+      <pre id="data"></pre>
+    </div>
+    <script type="module">
+      import * as IIIFHelpers from '@iiif/helpers';
 
-  let manifestUri = "https://digirati-co-uk.github.io/finsbury.json";
-  const vault = new IIIFVault.Vault();
+      let manifestUri = 'https://digirati-co-uk.github.io/finsbury.json';
+      const vault = new IIIFHelpers.Vault();
 
-  // a couple of helpers for displaying what we find
-  function show(obj, label) {
-    const data = document.getElementById("data");
-    const sep = "\n\n\n" + (label || "") + " ==========================================\n\n"
-    data.innerHTML = sep + JSON.stringify(obj, null, 2) + data.innerHTML;
-  }
-  function append(element) {
-    document.getElementById("app").appendChild(element);
-  }
-
-  async function demo() {
-
-
-    const manifest = await vault.loadManifest(manifestUri);
-    vault.setMetaValue(["ViewerState", "LoadedResources", "CurrentManifest"], manifest.id);
-    await vault.subscribe(
-      state => state.iiif.meta["ViewerState"],
-      selection => {
-        if (selection && selection.LoadedResources) {
-          LoadManifest(selection.LoadedResources.CurrentManifest);
-        }
+      // a couple of helpers for displaying what we find
+      function show(obj, label) {
+        const data = document.getElementById('data');
+        const sep = '\n\n\n' + (label || '') + ' ==========================================\n\n';
+        data.innerHTML = sep + JSON.stringify(obj, null, 2) + data.innerHTML;
       }
-    )
-  }
-
-  demo();
-
-  async function LoadManifest(manifestId) {
-
-    const manifest = await vault.loadManifest(manifestId);
-    const events = VaultHelpers.createEventsHelper(vault);
-    const thumbHelper = VaultHelpers.createThumbnailHelper(vault);
-
-    for (const canvas of manifest.items) {
-      // give these handlers a scope, we may wish to have other click handlers for the same canvases elsewhere
-      events.addEventListener(canvas, 'onClick', () => show(vault.get(canvas)), ["Thumbs"]);
-    }
-
-    await vault.subscribe(
-      state => state.iiif.entities.Manifest[manifestId], // (can't subscribe to [manifest.id].items)
-      (selection, vault) => {
-        // selection is the manifest. When the manifest changes...
-        document.getElementById("app").innerHTML = "";
-        for (const canvas of selection.items) {
-          // ...create an image element for each canvas
-          const thumb = document.createElement("img");
-          // const canvasManager = vault.getResourceMeta(canvas.id).eventManager;
-          const props = events.getListenersAsProps(canvas);
-          // thumb.addEventListener("click", canvasManager.onClick[0].callback);
-          thumb.addEventListener("click", props.onClick);
-          // ...set the src of the image to a vault-picked thumbnail
-          thumbHelper.getBestThumbnailAtSize(canvas, { maxWidth: 100 }).then(cvThumb => thumb.src = cvThumb.best.id);
-          append(thumb);
-        }
+      function append(element) {
+        document.getElementById('app').appendChild(element);
       }
-    )
-  }
 
+      async function demo() {
+        const manifest = await vault.loadManifest(manifestUri);
+        vault.setMetaValue(['ViewerState', 'LoadedResources', 'CurrentManifest'], manifest.id);
+        await vault.subscribe(
+          (state) => state.iiif.meta['ViewerState'],
+          (selection) => {
+            if (selection && selection.LoadedResources) {
+              LoadManifest(selection.LoadedResources.CurrentManifest);
+            }
+          }
+        );
+      }
 
-</script>
-</body>
+      demo();
 
+      async function LoadManifest(manifestId) {
+        const manifest = await vault.loadManifest(manifestId);
+        const events = VaultHelpers.createEventsHelper(vault);
+        const thumbHelper = VaultHelpers.createThumbnailHelper(vault);
+
+        for (const canvas of manifest.items) {
+          // give these handlers a scope, we may wish to have other click handlers for the same canvases elsewhere
+          events.addEventListener(canvas, 'onClick', () => show(vault.get(canvas)), ['Thumbs']);
+        }
+
+        await vault.subscribe(
+          (state) => state.iiif.entities.Manifest[manifestId], // (can't subscribe to [manifest.id].items)
+          (selection, vault) => {
+            // selection is the manifest. When the manifest changes...
+            document.getElementById('app').innerHTML = '';
+            for (const canvas of selection.items) {
+              // ...create an image element for each canvas
+              const thumb = document.createElement('img');
+              // const canvasManager = vault.getResourceMeta(canvas.id).eventManager;
+              const props = events.getListenersAsProps(canvas);
+              // thumb.addEventListener("click", canvasManager.onClick[0].callback);
+              thumb.addEventListener('click', props.onClick);
+              // ...set the src of the image to a vault-picked thumbnail
+              thumbHelper
+                .getBestThumbnailAtSize(canvas, { maxWidth: 100 })
+                .then((cvThumb) => (thumb.src = cvThumb.best.id));
+              append(thumb);
+            }
+          }
+        );
+      }
+    </script>
+  </body>
 </html>

--- a/packages/canvas-panel/demos/vault-custom.html
+++ b/packages/canvas-panel/demos/vault-custom.html
@@ -1,88 +1,86 @@
 <html>
-<head>
-  <meta charset='UTF-8'>
-  <meta name='viewport'
-        content='width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0'>
-  <meta http-equiv='X-UA-Compatible' content='ie=edge'>
-  <title>Document</title>
-  <script type='module' src='../src/index.ts'></script>
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Document</title>
+    <script type="module" src="../src/index.ts"></script>
+  </head>
+  <body>
+    <div id="root"></div>
 
-<div id="root"></div>
+    <script type="module">
+      import { Vault } from '@iiif/helpers/vault';
 
-  <script type="module">
-    import { Vault } from '@iiif/vault';
+      const myVault = new Vault();
 
-    const myVault = new Vault();
+      myVault.__NAME__ = 'MY VAULT';
 
-    myVault.__NAME__ = 'MY VAULT';
+      const $root = document.getElementById('root');
 
-    const $root = document.getElementById('root');
-
-    const inlineManifest = {
-      "@context": "http://iiif.io/api/presentation/3/context.json",
-      "id": "https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json",
-      "type": "Manifest",
-      "label": {
-        "en": [
-          "Picture of Göttingen taken during the 2019 IIIF Conference"
-        ]
-      },
-      "items": [
-        {
-          "id": "https://iiif.io/api/cookbook/recipe/0005-image-service/canvas/p1",
-          "type": "Canvas",
-          "label": {
-            "en": [
-              "Canvas with a single IIIF image"
-            ]
-          },
-          "height": 3024,
-          "width": 4032,
-          "items": [
-            {
-              "id": "https://iiif.io/api/cookbook/recipe/0005-image-service/page/p1/1",
-              "type": "AnnotationPage",
-              "items": [
-                {
-                  "id": "https://iiif.io/api/cookbook/recipe/0005-image-service/annotation/p0001-image",
-                  "type": "Annotation",
-                  "motivation": "painting",
-                  "body": {
-                    "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/max/0/default.jpg",
-                    "type": "Image",
-                    "format": "image/jpeg",
-                    "height": 3024,
-                    "width": 4032,
-                    "service": [
-                      {
-                        "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-                        "profile": "level1",
-                        "type": "ImageService3"
-                      }
-                    ]
+      const inlineManifest = {
+        '@context': 'http://iiif.io/api/presentation/3/context.json',
+        id: 'https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json',
+        type: 'Manifest',
+        label: {
+          en: ['Picture of Göttingen taken during the 2019 IIIF Conference'],
+        },
+        items: [
+          {
+            id: 'https://iiif.io/api/cookbook/recipe/0005-image-service/canvas/p1',
+            type: 'Canvas',
+            label: {
+              en: ['Canvas with a single IIIF image'],
+            },
+            height: 3024,
+            width: 4032,
+            items: [
+              {
+                id: 'https://iiif.io/api/cookbook/recipe/0005-image-service/page/p1/1',
+                type: 'AnnotationPage',
+                items: [
+                  {
+                    id: 'https://iiif.io/api/cookbook/recipe/0005-image-service/annotation/p0001-image',
+                    type: 'Annotation',
+                    motivation: 'painting',
+                    body: {
+                      id: 'https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/max/0/default.jpg',
+                      type: 'Image',
+                      format: 'image/jpeg',
+                      height: 3024,
+                      width: 4032,
+                      service: [
+                        {
+                          id: 'https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen',
+                          profile: 'level1',
+                          type: 'ImageService3',
+                        },
+                      ],
+                    },
+                    target: 'https://iiif.io/api/cookbook/recipe/0005-image-service/canvas/p1',
                   },
-                  "target": "https://iiif.io/api/cookbook/recipe/0005-image-service/canvas/p1"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    };
+                ],
+              },
+            ],
+          },
+        ],
+      };
 
-    // Not rendered.
-    const el = document.createElement('canvas-panel');
-    el.vault = myVault;
+      // Not rendered.
+      const el = document.createElement('canvas-panel');
+      el.vault = myVault;
 
-    const manifest = await myVault.loadManifest('https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json', inlineManifest);
+      const manifest = await myVault.loadManifest(
+        'https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json',
+        inlineManifest
+      );
 
-    el.setAttribute('canvas-id', manifest.items[0].id);
+      el.setAttribute('canvas-id', manifest.items[0].id);
 
-    $root.appendChild(el);
-
-
-  </script>
-</body>
+      $root.appendChild(el);
+    </script>
+  </body>
 </html>

--- a/packages/canvas-panel/package.json
+++ b/packages/canvas-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digirati/canvas-panel-web-components",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "typings": "./dist/types/index.d.ts",
   "main": "./dist/bundle.js",
   "files": [
@@ -15,22 +15,21 @@
   "resolutions": {
     "@atlas-viewer/iiif-image-api": "^2.1.1",
     "@iiif/presentation-3": ">=1.0.6",
-    "@iiif/vault": "^0.9.18",
-    "@iiif/parser": "1.*",
     "nanoid": "3.1.25"
   },
   "dependencies": {
-    "@atlas-viewer/atlas": "https://pkg.csb.dev/atlas-viewer/atlas/commit/9fc143d3/@atlas-viewer/atlas",
+    "@atlas-viewer/atlas": "https://pkg.csb.dev/atlas-viewer/atlas/commit/d74749b3/@atlas-viewer/atlas",
     "@atlas-viewer/iiif-image-api": "^2.1.1",
     "@iiif/presentation-2": "^1.0.4",
-    "@iiif/presentation-3": "^1.1.3",
-    "@iiif/vault": "^0.9.22",
-    "@iiif/vault-helpers": "^0.9.11",
+    "@iiif/presentation-3": "^2.1.3",
+    "@iiif/presentation-3-normalized": "^0.9.7",
+    "@iiif/helpers": "^1.0.6",
+    "@iiif/parser": "^2.0.2",
     "@preact/compat": "17.*",
     "@react-hook/media-query": "^1.1.1",
     "preact": "^10.*",
     "react-error-boundary": "^3.1.4",
-    "react-iiif-vault": "^0.9.21"
+    "react-iiif-vault": "^1.0.8"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.3.0",
@@ -50,7 +49,7 @@
     "preact-render-to-string": "^5.2.0",
     "prettier": "^2.5.1",
     "ts-jest": "^28.0.5",
-    "typescript": "^4.6.2",
+    "typescript": "^5.3.3",
     "vite": "^2.9.5",
     "vitest": "^0.18.0"
   },

--- a/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
+++ b/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
@@ -6,12 +6,11 @@ import {
   useThumbnail,
   StrategyActions,
   useVault,
-  ChoiceDescription,
   useVaultSelector,
   useAnnotationPageManager,
   useManifest,
 } from 'react-iiif-vault';
-import { createStylesHelper } from '@iiif/vault-helpers';
+import { createStylesHelper } from '@iiif/helpers';
 import { Fragment, h } from 'preact';
 import { WorldObject, SingleImage } from '../../atlas-components';
 import { RenderAnnotationPage } from '../RenderAnnotationPage/RenderAnnotationPage';
@@ -34,7 +33,7 @@ interface AtlasCanvasProps {
   highlightCssClass?: string;
   debug?: boolean;
   annoMode?: boolean;
-  onChoiceChange?: (choice?: ChoiceDescription) => void;
+  onChoiceChange?: (choice?: any) => void;
   defaultChoices?: Array<{ id: string; opacity?: number }>;
   onCreated?: any;
   registerActions?: (actions: StrategyActions) => void;

--- a/packages/canvas-panel/src/components/MetadataDisplay/MetadataDisplay.tsx
+++ b/packages/canvas-panel/src/components/MetadataDisplay/MetadataDisplay.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { InternationalString } from '@iiif/presentation-3';
 import { h } from 'preact';
-import { getValue } from '@iiif/vault-helpers';
+import { getValue } from '@iiif/helpers';
 import './MetadataDisplay.css';
 
 type FacetConfig = {

--- a/packages/canvas-panel/src/components/RangeDisplay/RangeDisplay.tsx
+++ b/packages/canvas-panel/src/components/RangeDisplay/RangeDisplay.tsx
@@ -1,9 +1,9 @@
 import { RangeContext, useManifest, useVault } from 'react-iiif-vault';
-import { findManifestSelectedRange, getValue } from '@iiif/vault-helpers';
+import { findManifestSelectedRange, getValue } from '@iiif/helpers';
 import { ViewRange } from './ViewRange';
 import { h } from 'preact';
 import { Fragment, useLayoutEffect } from 'preact/compat';
-import { RangeNormalized } from '@iiif/presentation-3';
+import { RangeNormalized } from '@iiif/presentation-3-normalized';
 import './RangeDisplay.css';
 
 export function RangeDisplay(props: {
@@ -45,7 +45,7 @@ export function RangeDisplay(props: {
     <Fragment>
       {selected ? <div className="range-current">{getValue(selected.label)}</div> : null}
 
-      {manifest.structures.map((range) => (
+      {manifest.structures.map((range: any) => (
         <RangeContext key={range.id} range={range.id}>
           <ViewRange selected={selected?.id} onRangeClick={props.onRangeClick} />
         </RangeContext>

--- a/packages/canvas-panel/src/components/RangeDisplay/ViewRange.tsx
+++ b/packages/canvas-panel/src/components/RangeDisplay/ViewRange.tsx
@@ -1,15 +1,15 @@
-import { findFirstCanvasFromRange, getValue, parseSelector, ParsedSelector } from '@iiif/vault-helpers';
+import { findFirstCanvasFromRange, getValue, parseSelector, ParsedSelector } from '@iiif/helpers';
 import { RangeContext, useRange, useVault } from 'react-iiif-vault';
 
 import { useMemo } from 'react';
 import { h } from 'preact';
-import { RangeNormalized } from '@iiif/presentation-3';
+import { RangeNormalized } from '@iiif/presentation-3-normalized';
 
 export function ViewRange(props: { selected?: string; onRangeClick?: (range: RangeNormalized, other: any) => void }) {
   const range = useRange();
   const vault = useVault();
-  const first = useMemo(() => range?.items.find((i) => i.type === 'Canvas'), [range]);
-  const hasSubsequentRanges = useMemo(() => !!range?.items.find((i) => i.type === 'Range'), [range]);
+  const first: any = useMemo(() => range?.items.find((i: any) => i.type === 'Canvas'), [range]);
+  const hasSubsequentRanges = useMemo(() => !!range?.items.find((i: any) => i.type === 'Range'), [range]);
   const selected = props.selected && props.selected === range?.id; // @todo how to get the selected?
 
   function onClick() {
@@ -24,14 +24,14 @@ export function ViewRange(props: { selected?: string; onRangeClick?: (range: Ran
         isLeaf: !hasSubsequentRanges,
       };
       if (first) {
-        const [cid, hash] = first.id?.split('#');
+        const [cid, hash] = (first.id || '').split('#');
         data.selector = first.id;
         data.canvasId = cid as string;
         data.fragment = hash as string;
       } else if (range) {
         const found = findFirstCanvasFromRange(vault, range);
         if (found) {
-          const [cid, hash] = found.id?.split('#');
+          const [cid, hash] = (found.id || '').split('#');
           data.selector = found.id;
           data.canvasId = cid;
           data.fragment = hash;
@@ -69,7 +69,7 @@ export function ViewRange(props: { selected?: string; onRangeClick?: (range: Ran
       ) : null}
       {hasSubsequentRanges ? (
         <div className="range-nested-container">
-          {range.items.map((range) => {
+          {range.items.map((range: any) => {
             if (range.type === 'Canvas' || (range as any).type === 'SpecificResource' || !range.id) {
               return null;
             }

--- a/packages/canvas-panel/src/components/RenderAllCanvases.tsx
+++ b/packages/canvas-panel/src/components/RenderAllCanvases.tsx
@@ -1,6 +1,5 @@
 import {
   CanvasContext as _CanvasContext,
-  ChoiceDescription,
   StrategyActions,
   useRange,
   useSimpleViewer,
@@ -11,6 +10,7 @@ import { SizeParameter } from '../helpers/size-parameter';
 import { h } from 'preact';
 import { Fragment, useEffect, useRef } from 'preact/compat';
 import { useRegisterPublicApi } from '../hooks/use-register-public-api';
+import { ChoiceDescription } from '@iiif/helpers';
 
 const CanvasContext = _CanvasContext as any;
 

--- a/packages/canvas-panel/src/components/RenderAnnotationPage/RenderAnnotationPage.tsx
+++ b/packages/canvas-panel/src/components/RenderAnnotationPage/RenderAnnotationPage.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'preact/compat';
-import { AnnotationPage, AnnotationPageNormalized } from '@iiif/presentation-3';
+import { AnnotationPage } from '@iiif/presentation-3';
+import { AnnotationPageNormalized } from '@iiif/presentation-3-normalized';
 import { Fragment, h } from 'preact';
 import { RenderAnnotation } from '../RenderAnnotation/RenderAnnotation';
 import { useStyles, useVaultSelector } from 'react-iiif-vault';

--- a/packages/canvas-panel/src/components/RenderTextLines/RenderTextFragment.tsx
+++ b/packages/canvas-panel/src/components/RenderTextLines/RenderTextFragment.tsx
@@ -1,5 +1,5 @@
 import { useAnnotation } from 'react-iiif-vault';
-import { BoxSelector } from '@iiif/vault-helpers/.build/types/annotation-targets/selector-types';
+import { BoxSelector } from '@iiif/helpers';
 import { Fragment } from 'preact/compat';
 import { h } from 'preact';
 

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
@@ -1,5 +1,6 @@
 import { AtlasProps } from '@atlas-viewer/atlas';
-import { ChoiceDescription, ParsedSelector } from 'react-iiif-vault';
+import { ParsedSelector } from 'react-iiif-vault';
+import { ChoiceDescription } from '@iiif/helpers';
 import { SizeParameter } from '../../helpers/size-parameter';
 
 export type AtlasDisplayOptions = AtlasProps & {

--- a/packages/canvas-panel/src/helpers/annotation-display.ts
+++ b/packages/canvas-panel/src/helpers/annotation-display.ts
@@ -1,8 +1,9 @@
-import { Vault } from '@iiif/vault';
+import { Vault } from '@iiif/helpers/vault';
 import { ClassList } from './class-list';
-import { AnnotationNormalized, Reference } from '@iiif/presentation-3';
+import { Reference } from '@iiif/presentation-3';
+import { AnnotationNormalized } from '@iiif/presentation-3-normalized';
 import { BoxStyle, mergeStyles } from '@atlas-viewer/atlas';
-import { createStylesHelper, StyledHelper, createEventsHelper } from '@iiif/vault-helpers';
+import { createStylesHelper, StyledHelper, createEventsHelper } from '@iiif/helpers';
 
 export class AnnotationDisplay {
   __vault: Vault | null = null;

--- a/packages/canvas-panel/src/helpers/sort-annotation-pages.ts
+++ b/packages/canvas-panel/src/helpers/sort-annotation-pages.ts
@@ -1,4 +1,4 @@
-import { Vault } from '@iiif/vault';
+import { Vault } from '@iiif/helpers/vault';
 
 export function sortAnnotationPages(availablePageIds: string[], vault: Vault) {
   const pagesWithTypes = [];

--- a/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
+++ b/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
@@ -14,9 +14,9 @@ import {
 import { Reference, Selector } from '@iiif/presentation-3';
 import { AnnotationDisplay } from '../helpers/annotation-display';
 import { ImageCandidateRequest } from '@atlas-viewer/iiif-image-api';
-import { createEventsHelper, createStylesHelper, createThumbnailHelper } from '@iiif/vault-helpers';
+import { createEventsHelper, createStylesHelper, createThumbnailHelper } from '@iiif/helpers';
 import { useEffect } from 'preact/compat';
-import { globalVault } from '@iiif/vault';
+import { globalVault } from '@iiif/helpers/vault';
 
 export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtlasComponent<T>) {
   const webComponent = useRef<HTMLElement>();

--- a/packages/canvas-panel/src/hooks/use-register-public-api.ts
+++ b/packages/canvas-panel/src/hooks/use-register-public-api.ts
@@ -1,19 +1,11 @@
-import {
-  ChoiceBody,
-  Annotation,
-  AnnotationNormalized,
-  CanvasNormalized,
-  ManifestNormalized,
-  Reference,
-  Selector,
-} from '@iiif/presentation-3';
-import { Vault } from '@iiif/vault';
+import { ChoiceBody, Annotation, Reference, Selector } from '@iiif/presentation-3';
+import { AnnotationNormalized, CanvasNormalized, ManifestNormalized } from '@iiif/presentation-3-normalized';
+import { Vault } from '@iiif/helpers/vault';
 import { createContext } from 'preact';
-import {useContext, useEffect, useRef} from 'preact/compat';
+import { useContext, useRef } from 'preact/compat';
 import { AnnotationDisplay } from '../helpers/annotation-display';
 import { ParsedSelector } from 'react-iiif-vault';
 import { BoxStyle } from '@atlas-viewer/atlas';
-import {useLayoutEffect} from "react";
 
 type TBC = any;
 

--- a/packages/canvas-panel/src/hooks/use-virtual-annotation-page-context.tsx
+++ b/packages/canvas-panel/src/hooks/use-virtual-annotation-page-context.tsx
@@ -1,7 +1,8 @@
 import { h, createContext } from 'preact';
 import { useVirtualAnnotationPage } from './use-virtual-annotation-page';
 import { useMemo, useContext } from 'preact/compat';
-import { Annotation, AnnotationNormalized, AnnotationPageNormalized } from '@iiif/presentation-3';
+import { Annotation } from '@iiif/presentation-3';
+import { AnnotationNormalized, AnnotationPageNormalized } from '@iiif/presentation-3-normalized';
 import { VaultActivatedAnnotation } from 'react-iiif-vault';
 
 const VirtualAnnotationPageContext = createContext<{

--- a/packages/canvas-panel/src/hooks/use-virtual-annotation-page.ts
+++ b/packages/canvas-panel/src/hooks/use-virtual-annotation-page.ts
@@ -1,9 +1,10 @@
-import { Annotation, AnnotationNormalized, AnnotationPageNormalized } from '@iiif/presentation-3';
+import { Annotation } from '@iiif/presentation-3';
+import { AnnotationNormalized, AnnotationPageNormalized } from '@iiif/presentation-3-normalized';
 import { useStyleHelper, useVault, useVirtualAnnotationPage as useVirtualAnnotationPageBase } from 'react-iiif-vault';
 import { useMemo, useRef } from 'preact/compat';
 import { useRegisterPublicApi } from './use-register-public-api';
 import { BoxStyle } from '@atlas-viewer/atlas';
-import { createEventsHelper } from '@iiif/vault-helpers';
+import { createEventsHelper } from '@iiif/helpers';
 import { VaultActivatedAnnotation } from 'react-iiif-vault/.build/types/hooks/useVirtualAnnotationPage';
 
 export function useVirtualAnnotationPage(): readonly [

--- a/packages/canvas-panel/src/types/content-state.ts
+++ b/packages/canvas-panel/src/types/content-state.ts
@@ -1,5 +1,5 @@
-import { ContentState, NormalisedContentState } from '@iiif/vault-helpers';
-import { BoxSelector } from '@iiif/vault-helpers/.build/types/annotation-targets/selector-types';
+import { ContentState, NormalisedContentState } from '@iiif/helpers';
+import { BoxSelector } from '@iiif/helpers';
 
 export interface ContentStateEvent {
   contentState: ContentState;

--- a/packages/canvas-panel/src/types/generic-atlas-component.ts
+++ b/packages/canvas-panel/src/types/generic-atlas-component.ts
@@ -1,6 +1,6 @@
 import { Selector } from '@iiif/presentation-3';
 import { SizeParameter } from '../helpers/size-parameter';
-import { Vault } from '@iiif/vault';
+import { Vault } from '@iiif/helpers/vault';
 
 export type GenericAtlasComponent<T = Record<never, never>, Props = any> = T & {
   region?: Selector | Selector[] | undefined; // same as target.

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -1,7 +1,8 @@
 import { h } from 'preact';
 import { FC, useCallback, useEffect, useLayoutEffect, useRef } from 'preact/compat';
 import register from '../library/preact-custom-element';
-import { CanvasContext, VaultProvider, ChoiceDescription } from 'react-iiif-vault';
+import { CanvasContext, VaultProvider } from 'react-iiif-vault';
+import { ChoiceDescription } from '@iiif/helpers';
 import { RegisterPublicApi, UseRegisterPublicApi } from '../hooks/use-register-public-api';
 import { ViewCanvas } from '../components/ViewCanvas/ViewCanvas';
 import { ManifestLoader } from '../components/manifest-loader';
@@ -15,7 +16,7 @@ import { ErrorFallback } from '../components/ErrorFallback/ErrorFallback';
 import { VirtualAnnotationProvider } from '../hooks/use-virtual-annotation-page-context';
 import { ContentStateCallback, ContentStateEvent } from '../types/content-state';
 import { DrawBox, easingFunctions, Projection, useAtlas } from '@atlas-viewer/atlas';
-import { ContentState } from '@iiif/vault-helpers';
+import { ContentState } from '@iiif/helpers';
 import { baseAttributes } from '../helpers/base-attributes';
 
 export type CanvasPanelProps = GenericAtlasComponent<

--- a/packages/canvas-panel/src/web-components/metadata-panel.tsx
+++ b/packages/canvas-panel/src/web-components/metadata-panel.tsx
@@ -1,7 +1,7 @@
 import { useSyncedState } from '../hooks/use-synced-state';
 import { parseBool, parseNumber } from '../helpers/parse-attributes';
 import { ManifestContext, useExistingVault, useExternalManifest, VaultProvider } from 'react-iiif-vault';
-import { globalVault, Vault } from '@iiif/vault';
+import { globalVault, Vault } from '@iiif/helpers/vault';
 import { Fragment, h } from 'preact';
 import { MetaDataDisplay } from '../components/MetadataDisplay/MetadataDisplay';
 import register from '../library/preact-custom-element';

--- a/packages/canvas-panel/src/web-components/range-panel.tsx
+++ b/packages/canvas-panel/src/web-components/range-panel.tsx
@@ -1,11 +1,11 @@
 import { useSyncedState } from '../hooks/use-synced-state';
 import { parseBool } from '../helpers/parse-attributes';
 import { ManifestContext, useExistingVault, useExternalManifest, VaultProvider } from 'react-iiif-vault';
-import { globalVault, Vault } from '@iiif/vault';
+import { globalVault, Vault } from '@iiif/helpers/vault';
 import { Fragment, h } from 'preact';
 import { RangeDisplay } from '../components/RangeDisplay/RangeDisplay';
 import { useLayoutEffect, useRef, useState } from 'preact/compat';
-import { RangeNormalized } from '@iiif/presentation-3';
+import { RangeNormalized } from '@iiif/presentation-3-normalized';
 import register from '../library/preact-custom-element';
 
 export interface RangePanelProps {

--- a/packages/canvas-panel/src/web-components/sequence-panel.tsx
+++ b/packages/canvas-panel/src/web-components/sequence-panel.tsx
@@ -1,7 +1,8 @@
 import register from '../library/preact-custom-element';
 import { GenericAtlasComponent } from '../types/generic-atlas-component';
 import { useGenericAtlasProps } from '../hooks/use-generic-atlas-props';
-import { ChoiceDescription, SimpleViewerProvider, VaultProvider } from 'react-iiif-vault';
+import { SimpleViewerProvider, VaultProvider } from 'react-iiif-vault';
+import { ChoiceDescription } from '@iiif/helpers';
 import { ViewCanvas } from '../components/ViewCanvas/ViewCanvas';
 import { RegisterPublicApi } from '../hooks/use-register-public-api';
 import { VirtualAnnotationProvider } from '../hooks/use-virtual-annotation-page-context';

--- a/packages/canvas-panel/vite/base-config.mjs
+++ b/packages/canvas-panel/vite/base-config.mjs
@@ -5,8 +5,8 @@ export const defaultExternal = [
   '@atlas-viewer/iiif-image-api',
   '@iiif/presentation-2',
   '@iiif/presentation-3',
-  '@iiif/vault',
-  '@iiif/vault-helpers',
+  '@iiif/helpers/vault',
+  '@iiif/helpers',
   '@preact/compat',
   '@react-hook/media-query',
   'preact',
@@ -42,9 +42,7 @@ export function defineConfig(options) {
           return `${format}/${options.name}.js`;
         },
       },
-      plugins: [
-        preact({ devtoolsInProd: true }),
-      ].filter(Boolean),
+      plugins: [preact({ devtoolsInProd: true })].filter(Boolean),
       rollupOptions: {
         treeshake: true,
         external: options.external,

--- a/packages/canvas-panel/vite/build.mjs
+++ b/packages/canvas-panel/vite/build.mjs
@@ -35,8 +35,8 @@ import chalk from 'chalk';
   //       '@atlas-viewer/iiif-image-api',
   //       '@iiif/presentation-2',
   //       '@iiif/presentation-3',
-  //       '@iiif/vault',
-  //       '@iiif/vault-helpers',
+  //       '@iiif/helpers/vault',
+  //       '@iiif/helpers',
   //       '@preact/compat',
   //       '@react-hook/media-query',
   //       'preact',
@@ -46,8 +46,7 @@ import chalk from 'chalk';
   //   })
   // );
 
-  console.log('')
-
+  console.log('');
 
   function buildMsg(name) {
     console.log(chalk.grey(`\n\nBuilding ${chalk.blue(name)}\n`));

--- a/packages/canvas-panel/yarn.lock
+++ b/packages/canvas-panel/yarn.lock
@@ -9,31 +9,15 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atlas-viewer/atlas@^2.0.0-alpha.19":
-  version "2.0.0-alpha.20"
-  resolved "https://registry.yarnpkg.com/@atlas-viewer/atlas/-/atlas-2.0.0-alpha.20.tgz#b909ceaab086b3cfea84eb90d2050efae2f63393"
-  integrity sha512-6sn+Z6VTr+dbIh/2EcLkNJfoHauUwhN6NyPs64ivS5GB6omv+qDTC2Au4W9MQ4lTV9mUKHn9cKUSWUcBV5K7Aw==
+"@atlas-viewer/atlas@>=2.0.4", "@atlas-viewer/atlas@https://pkg.csb.dev/atlas-viewer/atlas/commit/d74749b3/@atlas-viewer/atlas":
+  version "2.0.5"
+  resolved "https://pkg.csb.dev/atlas-viewer/atlas/commit/d74749b3/@atlas-viewer/atlas#705ffe0efe838f569426509d5009f45814c2e77f"
   dependencies:
     "@atlas-viewer/dna" "^0.5.0"
     "@atlas-viewer/iiif-image-api" "^2.0.5"
-    "@iiif/presentation-3" ">=1"
-    "@iiif/vault" "^0.9.18"
-    "@iiif/vault-helpers" "^0.9.7"
-    nanoid "^3.1.9"
-    normalize-wheel "^1.0.1"
-    react-reconciler "^0.26.2"
-    react-use-measure "^2.0.1"
-    scheduler "^0.21.0"
-
-"@atlas-viewer/atlas@https://pkg.csb.dev/atlas-viewer/atlas/commit/9fc143d3/@atlas-viewer/atlas":
-  version "2.0.0-alpha.21"
-  resolved "https://pkg.csb.dev/atlas-viewer/atlas/commit/9fc143d3/@atlas-viewer/atlas#9a7b026102bf7baedbe5f651f83500d3917bee81"
-  dependencies:
-    "@atlas-viewer/dna" "^0.5.0"
-    "@atlas-viewer/iiif-image-api" "^2.0.5"
-    "@iiif/presentation-3" ">=1"
-    "@iiif/vault" "^0.9.18"
-    "@iiif/vault-helpers" "^0.9.7"
+    "@iiif/helpers" "^1.0.3"
+    "@iiif/parser" "2.0.1"
+    "@iiif/presentation-3" ">=2"
     lru-cache "^7.17.0"
     nanoid "^3.1.9"
     normalize-wheel "^1.0.1"
@@ -46,7 +30,7 @@
   resolved "https://registry.yarnpkg.com/@atlas-viewer/dna/-/dna-0.5.0.tgz#aab824540b59dc3897e2ba4cdb51a53e47ed3311"
   integrity sha512-vHyMwXoCFq6ymk+wOVIkMphUo+I+wBRoA2tBf1AIUZWJMsk51cBtO2qzOaZQUh/TmrzrqEY5aEAtgBj52LVRUg==
 
-"@atlas-viewer/iiif-image-api@2.*", "@atlas-viewer/iiif-image-api@^2.0.5", "@atlas-viewer/iiif-image-api@^2.1.1":
+"@atlas-viewer/iiif-image-api@>=2.1.1", "@atlas-viewer/iiif-image-api@^2.0.5", "@atlas-viewer/iiif-image-api@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@atlas-viewer/iiif-image-api/-/iiif-image-api-2.1.1.tgz#da01b09e7d29c21f6524b6f632368f48e8eb9d5a"
   integrity sha512-g7gleRz0Guxwj/JqtppiqloabUTCew61GBzon+ZZ7mXpnMQ+zMupLaI1jHfGxM1Xy9a1+zMwPuUTXqTFkEyueA==
@@ -567,20 +551,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.14.5":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
-  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.9.2":
-  version "7.17.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
-  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -705,84 +675,58 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@iiif/parser@1.*", "@iiif/parser@>=v1.0.13", "@iiif/parser@^1.1.2":
+"@iiif/helpers@>=1.0.4", "@iiif/helpers@^1.0.3", "@iiif/helpers@^1.0.6":
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@iiif/parser/-/parser-1.0.6.tgz#0f5252b94ba586aade3d6558b5a649fa265fe217"
-  integrity sha512-bIdmqe3JwPopL7qEeZk193YNkGaEkkfSR9i/+B7I3MVXkKGE6G80tOWhfQRs/EY3fMzOS8OUFxzAu+aS6CXvEg==
+  resolved "https://registry.yarnpkg.com/@iiif/helpers/-/helpers-1.0.6.tgz#d9b8971d4db27ee7cce5d0e4e71964d055f16928"
+  integrity sha512-sI+6Ed9WBoh66Rk+z2oFY2vSZ2t4VIw3SJWKBFGLQbjeB6gHfsf7mlncXAEtscX1ZCr6S2w+RfcMXu/fOUo5PA==
   dependencies:
-    "@iiif/presentation-2" "^1.0.1"
-    "@iiif/presentation-3" "^1.0.4"
-    "@types/geojson" "^7946.0.8"
+    "@iiif/presentation-2" "1.0.4"
+    "@iiif/presentation-3" "2.1.3"
+    "@iiif/presentation-3-normalized" "0.9.7"
+    "@types/geojson" "7946.0.13"
+  optionalDependencies:
+    abs-svg-path "^0.1.1"
+    parse-svg-path "^0.1.2"
+    svg-arc-to-cubic-bezier "^3.2.0"
 
-"@iiif/presentation-2@1.*", "@iiif/presentation-2@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@iiif/presentation-2/-/presentation-2-1.0.1.tgz#0d76fedfeac65b31afcc30d9a8dc17f2e57041e4"
-  integrity sha512-iWF6rgAi9ksSwbH/4uJW1/49DOL1wN2mLKovu0qy1GYtCTg42bryAxYtnBsw6LrJZWykTStv7R3DynChfECmnA==
+"@iiif/parser@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@iiif/parser/-/parser-2.0.1.tgz#2140adb92b5b27db3c70104b069e20bc8cbdcb84"
+  integrity sha512-RnHzBnYiI49I+cV9uxkhvUBqNSqj90pX+0hRRZgQ51EO0Sww7l1G44e6pg66PFxiDsIRXrkk34I63fYB9L1VrA==
+  dependencies:
+    "@iiif/presentation-2" "^1.0.4"
+    "@iiif/presentation-3" "^2.1.3"
+    "@iiif/presentation-3-normalized" "^0.9.7"
+    "@types/geojson" "^7946.0.10"
 
-"@iiif/presentation-2@1.x", "@iiif/presentation-2@^1.0.4":
+"@iiif/parser@>=2.0.1", "@iiif/parser@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@iiif/parser/-/parser-2.0.2.tgz#0bd054429d635b197c7875cc45ad173658b7b834"
+  integrity sha512-ffqki1eJVVbWp1A+ulRgiojeCJH8eGyRIrAkyT60tHNXBWfYlkLTadFjFfyHlwWavT5BFI4nZtFTrwQXDtylQA==
+  dependencies:
+    "@iiif/presentation-2" "^1.0.4"
+    "@iiif/presentation-3" "^2.1.3"
+    "@iiif/presentation-3-normalized" "^0.9.7"
+    "@types/geojson" "^7946.0.10"
+
+"@iiif/presentation-2@1.0.4", "@iiif/presentation-2@>=1.*", "@iiif/presentation-2@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@iiif/presentation-2/-/presentation-2-1.0.4.tgz#1664aee995462fdf66ec8dfbae54fc22b4f79c97"
   integrity sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==
 
-"@iiif/presentation-3@*", "@iiif/presentation-3@1.*", "@iiif/presentation-3@1.x", "@iiif/presentation-3@>=1", "@iiif/presentation-3@>=1.0.6", "@iiif/presentation-3@^1.0.4", "@iiif/presentation-3@^1.1.2", "@iiif/presentation-3@^1.1.3":
+"@iiif/presentation-3-normalized@0.9.7", "@iiif/presentation-3-normalized@>=0.9.7", "@iiif/presentation-3-normalized@^0.9.7":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/@iiif/presentation-3-normalized/-/presentation-3-normalized-0.9.7.tgz#19386234e07c91c996d15ac5e1d86d1e1882e128"
+  integrity sha512-Aqk0sYBFIH5W3wmVxW02tnAFbNzUU5oPygGQjvszB3PP2nSkFQ1skVjqJhQPPZTyi/de1qcJUrgSy0vp6s+c5A==
+  dependencies:
+    "@iiif/presentation-3" "^2.0.5"
+
+"@iiif/presentation-3@*", "@iiif/presentation-3@2.1.3", "@iiif/presentation-3@>=1.0.6", "@iiif/presentation-3@>=2", "@iiif/presentation-3@>=2.1.3", "@iiif/presentation-3@^2.0.5", "@iiif/presentation-3@^2.1.3":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@iiif/presentation-3/-/presentation-3-1.0.6.tgz#bec210e4df2549c363733dc3215b20c4e9160a46"
   integrity sha512-00wzi4ocMe0bvxkYsv+SzWRPeN8ZHN2n86aJ2o2QpZiaVQ2AsewBPCMarGryAZ0x7CQv0yO9HV1xj6jiuhl9dQ==
   dependencies:
     "@types/geojson" "^7946.0.7"
-
-"@iiif/vault-helpers@>=0.9.7", "@iiif/vault-helpers@^0.9.7":
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/@iiif/vault-helpers/-/vault-helpers-0.9.7.tgz#fc3a35ed5e980a8fae13204c3ba4a4744fef3b90"
-  integrity sha512-nMsucZrgLnX5cRGSm1+UFwNRqiWXH4TupqbsnygIUp6wMUTiWeIv3KAh5xbib1keTYdOqENeOploDHRnK5r4Kg==
-  dependencies:
-    "@atlas-viewer/iiif-image-api" "2.*"
-    "@iiif/parser" "1.*"
-    "@iiif/presentation-2" "1.*"
-    "@iiif/presentation-3" "1.*"
-    "@iiif/vault" "0.9.*"
-    tiny-invariant "^1.2.0"
-
-"@iiif/vault-helpers@^0.9.11":
-  version "0.9.11"
-  resolved "https://registry.yarnpkg.com/@iiif/vault-helpers/-/vault-helpers-0.9.11.tgz#43a28e4600d41990997a2225e9272491bddc7d57"
-  integrity sha512-4XuFPvu233mMzfU/mMpAqFY5aCTzwhJ0u7MzPcpN8nSfMwbV5Dyvv0PppjcocvbWMUUXScqerRoB1MAfSFas6w==
-  dependencies:
-    "@iiif/presentation-2" "1.x"
-    "@iiif/presentation-3" "1.x"
-  optionalDependencies:
-    abs-svg-path "^0.1.0"
-    parse-svg-path "^0.1.0"
-    react-i18next "^11.18.0"
-    svg-arc-to-cubic-bezier "^3.2.0"
-
-"@iiif/vault@0.9.*", "@iiif/vault@>=0.9.19", "@iiif/vault@^0.9.18":
-  version "0.9.18"
-  resolved "https://registry.yarnpkg.com/@iiif/vault/-/vault-0.9.18.tgz#07d6a90411f45a764635c95908b5b67c873a8384"
-  integrity sha512-714/6X5ZyIuiDGeElUZx1mm8nKFabtxORzfMX7MZyc4IAtASjn1HK68xfTtyolN2cFYDhqFiY3Tz08F7HNIKGQ==
-  dependencies:
-    "@iiif/parser" "1.*"
-    "@iiif/presentation-2" "1.*"
-    "@iiif/presentation-3" "1.*"
-    mitt "^3.0.0"
-    node-fetch "^3.1.1"
-    redux "^4.1.2"
-    tiny-invariant "^1.2.0"
-    typesafe-actions "^5.1.0"
-
-"@iiif/vault@^0.9.22":
-  version "0.9.22"
-  resolved "https://registry.yarnpkg.com/@iiif/vault/-/vault-0.9.22.tgz#299bd3e6df1e4c3ae941d272b298ae65280b69d0"
-  integrity sha512-HaFX1u9TSZha0i/esZR5sZzydZgjZgITeO0JrT1qXm+qSaB1Oc0PRNzatXW48Xa0q3PPYbBB71zCL1/D1i1i1A==
-  dependencies:
-    "@iiif/parser" "^1.1.2"
-    "@iiif/presentation-2" "1.*"
-    "@iiif/presentation-3" "^1.1.3"
-    mitt "^3.0.0"
-    node-fetch "^3.1.1"
-    redux "^4.1.2"
-    tiny-invariant "^1.2.0"
-    typesafe-actions "^5.1.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1190,7 +1134,17 @@
   dependencies:
     "@types/node" "*"
 
-"@types/geojson@^7946.0.7", "@types/geojson@^7946.0.8":
+"@types/geojson@7946.0.13":
+  version "7946.0.13"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.13.tgz#e6e77ea9ecf36564980a861e24e62a095988775e"
+  integrity sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==
+
+"@types/geojson@^7946.0.10":
+  version "7946.0.14"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.14.tgz#319b63ad6df705ee2a65a73ef042c8271e696613"
+  integrity sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==
+
+"@types/geojson@^7946.0.7":
   version "7946.0.8"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
   integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
@@ -1389,7 +1343,7 @@
     "@typescript-eslint/types" "5.14.0"
     eslint-visitor-keys "^3.0.0"
 
-abs-svg-path@^0.1.0:
+abs-svg-path@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/abs-svg-path/-/abs-svg-path-0.1.1.tgz#df601c8e8d2ba10d4a76d625e236a9a39c2723bf"
   integrity sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==
@@ -2618,13 +2572,6 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-html-parse-stringify@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
-  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
-  dependencies:
-    void-elements "3.1.0"
-
 http-basic@^8.1.1:
   version "8.1.3"
   resolved "https://registry.yarnpkg.com/http-basic/-/http-basic-8.1.3.tgz#a7cabee7526869b9b710136970805b1004261bbf"
@@ -3361,11 +3308,6 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mitt@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
-  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -3393,7 +3335,7 @@ node-fetch@^2.x.x:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^3.1.1, node-fetch@^3.2.0:
+node-fetch@^3.2.0:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.3.tgz#a03c9cc2044d21d1a021566bd52f080f333719a6"
   integrity sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==
@@ -3511,7 +3453,7 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse-svg-path@^0.1.0:
+parse-svg-path@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/parse-svg-path/-/parse-svg-path-0.1.2.tgz#7a7ec0d1eb06fa5325c7d3e009b859a09b5d49eb"
   integrity sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==
@@ -3692,32 +3634,21 @@ react-error-boundary@^3.1.4:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-react-i18next@^11.18.0:
-  version "11.18.6"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.18.6.tgz#e159c2960c718c1314f1e8fcaa282d1c8b167887"
-  integrity sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==
+react-iiif-vault@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/react-iiif-vault/-/react-iiif-vault-1.0.8.tgz#6a9eb0ae6df31e04971b98b4c98ce8c45e38d638"
+  integrity sha512-ya/rDWW5LvL5NEpjEVueNUPuWiy+EoatFmXd20EjkK+XFRS0Ox+YDFFESC1y63kHlDIwX9e1BAgSWtK524OLWQ==
   dependencies:
-    "@babel/runtime" "^7.14.5"
-    html-parse-stringify "^3.0.1"
-
-react-iiif-vault@^0.9.21:
-  version "0.9.21"
-  resolved "https://registry.yarnpkg.com/react-iiif-vault/-/react-iiif-vault-0.9.21.tgz#613526e9d05f84dc5506e154942e71e9e7f389d8"
-  integrity sha512-sYwbUBwTI3lxV5x6SyHszTWnNw44fafZcV5ltwvuF+8cmlOcDLeeoj0B2f3tW+UNkRIaRVjc1xcNOPPixP/mkA==
-  dependencies:
-    "@atlas-viewer/atlas" "^2.0.0-alpha.19"
-    "@atlas-viewer/iiif-image-api" "2.*"
-    "@iiif/parser" ">=v1.0.13"
-    "@iiif/presentation-2" "1.*"
-    "@iiif/presentation-3" "^1.1.2"
-    "@iiif/vault" ">=0.9.19"
-    "@iiif/vault-helpers" ">=0.9.7"
+    "@atlas-viewer/atlas" ">=2.0.4"
+    "@atlas-viewer/iiif-image-api" ">=2.1.1"
+    "@iiif/helpers" ">=1.0.4"
+    "@iiif/parser" ">=2.0.1"
+    "@iiif/presentation-2" ">=1.*"
+    "@iiif/presentation-3" ">=2.1.3"
+    "@iiif/presentation-3-normalized" ">=0.9.7"
     react "^16.10.2 || ^17.0.2 || ^18.2.0"
     react-dom "^16.10.2 || ^17.0.2 || ^18.2.0"
     react-error-boundary "^3.1.4"
-    redux "^4.2.0"
-    typescript "^4.7.4"
-    use-sync-external-store "^1.2.0"
 
 react-is@^18.0.0:
   version "18.2.0"
@@ -3759,13 +3690,6 @@ readable-stream@^2.2.2:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-redux@^4.1.2, redux@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
-  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"
@@ -4104,11 +4028,6 @@ throat@^6.0.1:
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
-tiny-invariant@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
-  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
-
 tinypool@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.2.tgz#9b1da3a4f0c8c44c04e8af8783d9f27f1795bda2"
@@ -4194,20 +4113,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typesafe-actions@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-5.1.0.tgz#9afe8b1e6a323af1fd59e6a57b11b7dd6623d2f1"
-  integrity sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==
-
-typescript@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
-
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 update-browserslist-db@^1.0.4:
   version "1.0.4"
@@ -4223,11 +4132,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-use-sync-external-store@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -4286,11 +4190,6 @@ vitest@^0.18.0:
     tinypool "^0.2.1"
     tinyspy "^0.3.3"
     vite "^2.9.12 || ^3.0.0-0"
-
-void-elements@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
-  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
 vscode-json-languageservice@^4.1.6:
   version "4.1.9"

--- a/sandboxes/10-choices/simpleChoice.csb/src/index.js
+++ b/sandboxes/10-choices/simpleChoice.csb/src/index.js
@@ -1,10 +1,12 @@
-import '@digirati/canvas-panel-web-components';
-import { getValue } from '@iiif/vault-helpers';
-import './styles.css';
+import "@digirati/canvas-panel-web-components";
+import { getValue } from "@iiif/helpers";
+import "./styles.css";
 
 async function load() {
   const cp = document.getElementById("cp");
-  await cp.vault.loadManifest("https://preview.iiif.io/cookbook/3333-choice/recipe/0033-choice/manifest.json");
+  await cp.vault.loadManifest(
+    "https://preview.iiif.io/cookbook/3333-choice/recipe/0033-choice/manifest.json"
+  );
   cp.addEventListener("choice", (e) => {
     let msg = "  Choices: ";
     for (const choice of e.detail.choice.items) {
@@ -13,7 +15,9 @@ async function load() {
     }
     document.getElementById("pseudoUI").innerText = msg;
   });
-  cp.setCanvas("https://preview.iiif.io/cookbook/3333-choice/recipe/0033-choice/canvas/p1");
+  cp.setCanvas(
+    "https://preview.iiif.io/cookbook/3333-choice/recipe/0033-choice/canvas/p1"
+  );
 }
 
 load();

--- a/sandboxes/vue-carousel.csb/package.json
+++ b/sandboxes/vue-carousel.csb/package.json
@@ -10,8 +10,7 @@
   },
   "dependencies": {
     "@digirati/canvas-panel-web-components": "*",
-    "@iiif/vault": "0.9.14",
-    "@iiif/vault-helpers": "0.9.4",
+    "@iiif/helpers": "^1.0.6",
     "core-js": "^3.6.5",
     "vue": "^3.0.0-0"
   },

--- a/sandboxes/vue-carousel.csb/src/App.vue
+++ b/sandboxes/vue-carousel.csb/src/App.vue
@@ -9,10 +9,9 @@
 </template>
 
 <script>
-import { globalVault } from "@iiif/vault";
 import Manifest from "./components/Manifest";
 import ManifestThumbnailList from "./components/ManifestThumbnailList";
-import { createThumbnailHelper } from "@iiif/vault-helpers";
+import { createThumbnailHelper, globalVault } from "@iiif/helpers";
 
 export default {
   name: "App",
@@ -37,7 +36,8 @@ export default {
 </script>
 
 <style>
-:root html, :root  body {
+:root html,
+:root body {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/sandboxes/vue-sandbox.csb/package.json
+++ b/sandboxes/vue-sandbox.csb/package.json
@@ -4,7 +4,6 @@
   "main": "./src/index.js",
   "dependencies": {
     "@digirati/canvas-panel-web-components": "*",
-    "@iiif/vault": "^0.9.14",
-    "@iiif/vault-helpers": "^0.9.4"
+    "@iiif/helpers": "^1.0.6"
   }
 }

--- a/static/demos/bookreader.html
+++ b/static/demos/bookreader.html
@@ -1,103 +1,134 @@
 <html>
-<head>
+  <head>
     <title>Bookreader</title>
     <style>
-        #manifest { width: 50vw; }
-        #th { width:240px; border-right: 1px solid #999; margin: 5px; float:left; height:90%; overflow-y:scroll; }        
-        #main { width:72vw; margin-top:30px; margin-left:10px; float:left; height:90%;} 
-        .tc { display: inline-block; padding:5px; cursor: pointer; min-width: 100; }
-        #viewportContainer { height:80%; background-color: black; display: flex }
-        sequence-panel {
-            display: flex;
-            flex-direction: column;
-            flex: 1;
-            min-width: 0; /* Required for downsizing */
+      #manifest {
+        width: 50vw;
+      }
+      #th {
+        width: 240px;
+        border-right: 1px solid #999;
+        margin: 5px;
+        float: left;
+        height: 90%;
+        overflow-y: scroll;
+      }
+      #main {
+        width: 72vw;
+        margin-top: 30px;
+        margin-left: 10px;
+        float: left;
+        height: 90%;
+      }
+      .tc {
+        display: inline-block;
+        padding: 5px;
+        cursor: pointer;
+        min-width: 100;
+      }
+      #viewportContainer {
+        height: 80%;
+        background-color: black;
+        display: flex;
+      }
+      sequence-panel {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0; /* Required for downsizing */
 
-            --atlas-container-flex: 1 1 0px;
-            --atlas-background: #000;
-        }
+        --atlas-container-flex: 1 1 0px;
+        --atlas-background: #000;
+      }
 
-        /* #cp { height:100% } */
+      /* #cp { height:100% } */
     </style>
     <script src="https://pkg.csb.dev/digirati-co-uk/iiif-canvas-panel/commit/b239c900/@digirati/canvas-panel-web-components/dist/bundle.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault@latest/dist/index.umd.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
-</head>
-<body>
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
+  </head>
+  <body>
     <h1>A bookreader using Canvas Panel and Layout Container</h1>
     <h2 id="manifestLabel"></h2>
-    <div>    
-        <input id="manifest" type="text" value="https://iiif.wellcomecollection.org/presentation/b18035723" />
-        <input id="go" type="button" value="Go" />
-    </div>    
-    <div>    
-        <div id="th"></div>
-        <div id="main">
-            <div id="viewportContainer">
-
-            </div>
-            <p id="cvLabel"></p>
-        </div>
+    <div>
+      <input
+        id="manifest"
+        type="text"
+        value="https://iiif.wellcomecollection.org/presentation/b18035723"
+      />
+      <input id="go" type="button" value="Go" />
+    </div>
+    <div>
+      <div id="th"></div>
+      <div id="main">
+        <div id="viewportContainer"></div>
+        <p id="cvLabel"></p>
+      </div>
     </div>
 
-    <script>    
-        function $(id) { return document.getElementById(id); }
-        const vault = new IIIFVault.Vault();
-        const thumbHelper = VaultHelpers.createThumbnailHelper(vault);
-        let manifest;
+    <script>
+      function $(id) {
+        return document.getElementById(id);
+      }
+      const vault = new IIIFHelpers.Vault();
+      const thumbHelper = IIIFHelpers.createThumbnailHelper(vault);
+      let manifest;
 
-        async function loadManifest(){
-            const manifestUri = $("manifest").value;
-            if(manifestUri){
-                manifest = await vault.loadManifest(manifestUri);     
-                
-                const viewportContainer = $("viewportContainer");
-                viewportContainer.innerHTML = '';
-                // New component.
-                const sequencePanel = document.createElement('sequence-panel');
-                sequencePanel.vault = vault;
-                sequencePanel.setAttribute('manifest-id', manifestUri);
-                sequencePanel.setAttribute('margin', '20');
-                viewportContainer.appendChild(sequencePanel);
-                
-                $("manifestLabel").innerText = VaultHelpers.getValue(manifest.label);      
-                let thumbsHtml = "";
-                let counter = 1;
-                // for brevity we will assume that the manifest is "paged", the viewingDirection is left-to-right.
-                thumbsHtml += '<div class="tc"></div>';
-                for(const canvasRef of vault.get(manifest.items)){  
-                    const canvas = vault.get(canvasRef);            
-                    const label = VaultHelpers.getValue(canvas.label);
-                    thumbsHtml += `<div class="tc">${label}<br/>`;
-                    thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" data-index="${counter}" />`;
-                    thumbsHtml += '</div>';   
-                    counter++;
-                }
-                $('th').innerHTML = thumbsHtml;    
-                const thumbs = document.querySelectorAll('#th img');      
-                for(const thumb of thumbs){
-                    thumb.addEventListener('click', () => {
-                        if (sequencePanel.sequence) {
-                            sequencePanel.sequence.setCurrentCanvasId(thumb.getAttribute('data-uri'));                        
-                        }
-                    });
-                }  
-                sequencePanel.addEventListener("sequence-change", () => {
-                    // Update the page labels for both visible canvases
-                    const sequence = sequencePanel.sequence;
-                    const itemIndexes = sequence.sequence[sequence.currentSequenceIndex]; 
-                    const canvasRefs = itemIndexes.map(idx => sequence.items[idx]);
-                    const canvases = vault.get(canvasRefs);
-                    const labels = canvases.map(canvas => VaultHelpers.getValue(canvas.label));
-                    $("cvLabel").innerText = labels.join(" | ");  
-                });
-                thumbs[0].click();
-            }
+      async function loadManifest() {
+        const manifestUri = $("manifest").value;
+        if (manifestUri) {
+          manifest = await vault.loadManifest(manifestUri);
+
+          const viewportContainer = $("viewportContainer");
+          viewportContainer.innerHTML = "";
+          // New component.
+          const sequencePanel = document.createElement("sequence-panel");
+          sequencePanel.vault = vault;
+          sequencePanel.setAttribute("manifest-id", manifestUri);
+          sequencePanel.setAttribute("margin", "20");
+          viewportContainer.appendChild(sequencePanel);
+
+          $("manifestLabel").innerText = IIIFHelpers.getValue(manifest.label);
+          let thumbsHtml = "";
+          let counter = 1;
+          // for brevity we will assume that the manifest is "paged", the viewingDirection is left-to-right.
+          thumbsHtml += '<div class="tc"></div>';
+          for (const canvasRef of vault.get(manifest.items)) {
+            const canvas = vault.get(canvasRef);
+            const label = IIIFHelpers.getValue(canvas.label);
+            thumbsHtml += `<div class="tc">${label}<br/>`;
+            thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" data-index="${counter}" />`;
+            thumbsHtml += "</div>";
+            counter++;
+          }
+          $("th").innerHTML = thumbsHtml;
+          const thumbs = document.querySelectorAll("#th img");
+          for (const thumb of thumbs) {
+            thumb.addEventListener("click", () => {
+              if (sequencePanel.sequence) {
+                sequencePanel.sequence.setCurrentCanvasId(
+                  thumb.getAttribute("data-uri")
+                );
+              }
+            });
+          }
+          sequencePanel.addEventListener("sequence-change", () => {
+            // Update the page labels for both visible canvases
+            const sequence = sequencePanel.sequence;
+            const itemIndexes =
+              sequence.sequence[sequence.currentSequenceIndex];
+            const canvasRefs = itemIndexes.map((idx) => sequence.items[idx]);
+            const canvases = vault.get(canvasRefs);
+            const labels = canvases.map((canvas) =>
+              IIIFHelpers.getValue(canvas.label)
+            );
+            $("cvLabel").innerText = labels.join(" | ");
+          });
+          thumbs[0].click();
         }
-        
-        $("go").addEventListener('click', loadManifest);
-        loadManifest();        
+      }
 
-     </script>
-</body>
+      $("go").addEventListener("click", loadManifest);
+      loadManifest();
+    </script>
+  </body>
 </html>

--- a/static/demos/bookreaderA.html
+++ b/static/demos/bookreaderA.html
@@ -1,173 +1,212 @@
 <html>
-<head>
+  <head>
     <title>Bookreader</title>
     <style>
-        #manifest { width: 50vw; }
-        #th { width:240px; border-right: 1px solid #999; margin: 5px; float:left; height:90%; overflow-y:scroll; }        
-        #main { width:72vw; margin-top:30px; margin-left:10px; float:left; height:90%;} 
-        .tc { display: inline-block; padding:5px; cursor: pointer; min-width: 100; }
-        #viewportContainer { height:80%; background-color: black; display: flex }
-        sequence-panel {
-            display: flex;
-            flex-direction: column;
-            flex: 1;
-            min-width: 0; /* Required for downsizing */
+      #manifest {
+        width: 50vw;
+      }
+      #th {
+        width: 240px;
+        border-right: 1px solid #999;
+        margin: 5px;
+        float: left;
+        height: 90%;
+        overflow-y: scroll;
+      }
+      #main {
+        width: 72vw;
+        margin-top: 30px;
+        margin-left: 10px;
+        float: left;
+        height: 90%;
+      }
+      .tc {
+        display: inline-block;
+        padding: 5px;
+        cursor: pointer;
+        min-width: 100;
+      }
+      #viewportContainer {
+        height: 80%;
+        background-color: black;
+        display: flex;
+      }
+      sequence-panel {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0; /* Required for downsizing */
 
-            --atlas-container-flex: 1 1 0px;
-            --atlas-background: #000;
-        }
+        --atlas-container-flex: 1 1 0px;
+        --atlas-background: #000;
+      }
 
-        /* #cp { height:100% } */
+      /* #cp { height:100% } */
     </style>
     <script src="https://pkg.csb.dev/digirati-co-uk/iiif-canvas-panel/commit/b239c900/@digirati/canvas-panel-web-components/dist/bundle.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault@latest/dist/index.umd.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
-</head>
-<body>
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
+  </head>
+  <body>
     <h1>A bookreader using Canvas Panel and Layout Container</h1>
     <h2 id="manifestLabel"></h2>
-    <div>    
-        <input id="manifest" type="text" value="https://iiif.wellcomecollection.org/presentation/b18035723" />
-        <input id="go" type="button" value="Go" />
-    </div>    
-    <div>    
-        <div id="th"></div>
-        <div id="main">
-            <div id="viewportContainer">
-                <layout-container width="800" preset="zoom">
-                    <canvas-panel nested="true" 
-                        manifest-id="https://iiif.wellcomecollection.org/presentation/b18035723" 
-                        canvas-id="https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0003.JP2"></canvas-panel>
-                    <canvas-panel nested="true" 
-                        manifest-id="https://iiif.wellcomecollection.org/presentation/b18035723" 
-                        canvas-id="https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0004.JP2"></canvas-panel>
-                </layout-container>
-            </div>
-            <p id="cvLabel"></p>
+    <div>
+      <input
+        id="manifest"
+        type="text"
+        value="https://iiif.wellcomecollection.org/presentation/b18035723"
+      />
+      <input id="go" type="button" value="Go" />
+    </div>
+    <div>
+      <div id="th"></div>
+      <div id="main">
+        <div id="viewportContainer">
+          <layout-container width="800" preset="zoom">
+            <canvas-panel
+              nested="true"
+              manifest-id="https://iiif.wellcomecollection.org/presentation/b18035723"
+              canvas-id="https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0003.JP2"
+            ></canvas-panel>
+            <canvas-panel
+              nested="true"
+              manifest-id="https://iiif.wellcomecollection.org/presentation/b18035723"
+              canvas-id="https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0004.JP2"
+            ></canvas-panel>
+          </layout-container>
         </div>
+        <p id="cvLabel"></p>
+      </div>
     </div>
 
-    <script>    
-        function $(id) { return document.getElementById(id); }
-        const vault = new IIIFVault.Vault();
-        const thumbHelper = VaultHelpers.createThumbnailHelper(vault);
-        let manifest;
+    <script>
+      function $(id) {
+        return document.getElementById(id);
+      }
+      const vault = new IIIFHelpers.Vault();
+      const thumbHelper = IIIFHelpers.createThumbnailHelper(vault);
+      let manifest;
 
-        async function loadManifest(){
-            const manifestUri = $("manifest").value;
-            if(manifestUri){
-                manifest = await vault.loadManifest(manifestUri);     
-                
-                const viewportContainer = $("viewportContainer");
-                viewportContainer.innerHTML = '';
-                // New component.
-                const sequencePanel = document.createElement('sequence-panel');
-                sequencePanel.vault = vault;
-                sequencePanel.setAttribute('manifest-id', manifestUri);
-                sequencePanel.setAttribute('margin', '20');
-                // sequencePanel.setAttribute('text-enabled', 'true');
-                // sequencePanel.setAttribute('text-selection-enabled', 'true');
-                viewportContainer.appendChild(sequencePanel);
-                
-                $("manifestLabel").innerText = VaultHelpers.getValue(manifest.label);      
-                let thumbsHtml = "";
-                let counter = 1;
-                // for brevity we will assume that the manifest is "paged", the viewingDirection is left-to-right.
-                thumbsHtml += '<div class="tc"></div>';
-                for(const canvas of vault.get(manifest.items)){              
-                    const label = VaultHelpers.getValue(canvas.label);
-                    const cvThumb = await thumbHelper.getBestThumbnailAtSize(canvas, {maxWidth:100, maxHeight:200, dereference: false});
-                    thumbsHtml += `<div class="tc">${label}<br/>`;
-                    thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${cvThumb.best.id}" data-index="${counter}" />`;
-                    thumbsHtml += '</div>';   
-                    counter++;
-                }
-                $('th').innerHTML = thumbsHtml;    
-                const thumbs = document.querySelectorAll('#th img');      
-                for(const thumb of thumbs){
-                    // thumb.addEventListener('click', selectCanvas);
-                    thumb.addEventListener('click', () => {
-                        // Change the canvas.
-                        if (sequencePanel.sequence) {
-                            sequencePanel.sequence.setCurrentCanvasId(thumb.getAttribute('data-uri'))
-                        }
-                    });
-                }  
-                thumbs[0].click();
-            }
+      async function loadManifest() {
+        const manifestUri = $("manifest").value;
+        if (manifestUri) {
+          manifest = await vault.loadManifest(manifestUri);
+
+          const viewportContainer = $("viewportContainer");
+          viewportContainer.innerHTML = "";
+          // New component.
+          const sequencePanel = document.createElement("sequence-panel");
+          sequencePanel.vault = vault;
+          sequencePanel.setAttribute("manifest-id", manifestUri);
+          sequencePanel.setAttribute("margin", "20");
+          // sequencePanel.setAttribute('text-enabled', 'true');
+          // sequencePanel.setAttribute('text-selection-enabled', 'true');
+          viewportContainer.appendChild(sequencePanel);
+
+          $("manifestLabel").innerText = IIIFHelpers.getValue(manifest.label);
+          let thumbsHtml = "";
+          let counter = 1;
+          // for brevity we will assume that the manifest is "paged", the viewingDirection is left-to-right.
+          thumbsHtml += '<div class="tc"></div>';
+          for (const canvas of vault.get(manifest.items)) {
+            const label = IIIFHelpers.getValue(canvas.label);
+            const cvThumb = await thumbHelper.getBestThumbnailAtSize(canvas, {
+              maxWidth: 100,
+              maxHeight: 200,
+              dereference: false,
+            });
+            thumbsHtml += `<div class="tc">${label}<br/>`;
+            thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${cvThumb.best.id}" data-index="${counter}" />`;
+            thumbsHtml += "</div>";
+            counter++;
+          }
+          $("th").innerHTML = thumbsHtml;
+          const thumbs = document.querySelectorAll("#th img");
+          for (const thumb of thumbs) {
+            // thumb.addEventListener('click', selectCanvas);
+            thumb.addEventListener("click", () => {
+              // Change the canvas.
+              if (sequencePanel.sequence) {
+                sequencePanel.sequence.setCurrentCanvasId(
+                  thumb.getAttribute("data-uri")
+                );
+              }
+            });
+          }
+          thumbs[0].click();
         }
-        
+      }
 
-        $("go").addEventListener('click', loadManifest);
-        // loadManifest();
-        
+      $("go").addEventListener("click", loadManifest);
+      // loadManifest();
 
-        // Unused.
-        function selectCanvas(){
-            var clickedCanvas = vault.get(this.getAttribute("data-uri"));
-            const viewportContainer = $("viewportContainer");
-            // var layout = document.createElement("atlas-viewer");
-            var layout = document.createElement("sequence-panel");
-            layout.setAttribute("preset", "zoom");
-            layout.setAttribute("manifest-id", manif);
-            viewportContainer.replaceChildren();            
-            viewportContainer.appendChild(layout);
+      // Unused.
+      function selectCanvas() {
+        var clickedCanvas = vault.get(this.getAttribute("data-uri"));
+        const viewportContainer = $("viewportContainer");
+        // var layout = document.createElement("atlas-viewer");
+        var layout = document.createElement("sequence-panel");
+        layout.setAttribute("preset", "zoom");
+        layout.setAttribute("manifest-id", manif);
+        viewportContainer.replaceChildren();
+        viewportContainer.appendChild(layout);
 
-            let leftCanvas, rightCanvas, otherCanvas;
-            let cpLeft, cpRight, cpOther;
-            let leftLabel, rightLabel, otherLabel;
+        let leftCanvas, rightCanvas, otherCanvas;
+        let cpLeft, cpRight, cpOther;
+        let leftLabel, rightLabel, otherLabel;
 
-            const index = parseInt(this.getAttribute("data-index"));
-            let otherIndex;
+        const index = parseInt(this.getAttribute("data-index"));
+        let otherIndex;
 
-            if(index % 2 == 0){
-                cpLeft = createNestedCanvasPanelElement(clickedCanvas.id);           
-                leftLabel = this.getAttribute("data-label");
-                otherIndex = index + 1;             
-            } else {
-                cpRight = createNestedCanvasPanelElement(clickedCanvas.id);                         
-                rightLabel = this.getAttribute("data-label");
-                otherIndex = index - 1;  
-            }
-            const otherThumb = document.querySelector(`[data-index="${otherIndex}"]`);
-            if(otherThumb){
-                otherCanvas = vault.get(otherThumb.getAttribute("data-uri"));
-                cpOther = createNestedCanvasPanelElement(otherCanvas.id); 
-                otherLabel = otherThumb.getAttribute("data-label");
-            }
-            offsetCanvas = clickedCanvas;
-            if(cpLeft){
-                cpRight = cpOther;
-            } else {
-                cpLeft = cpOther;
-                if(otherCanvas){
-                    offsetCanvas = otherCanvas;
-                }
-            }
-            if(cpLeft){
-                layout.appendChild(cpLeft);
-            }
-            if(cpRight){
-                cpRight.setAttribute("x", offsetCanvas.width + 10);
-                layout.appendChild(cpRight);
-            }
-            let label;
-            if(leftLabel){
-                label = `${leftLabel} | ${otherLabel}`;
-            } else {
-                label = `${otherLabel} | ${rightLabel}`;
-            }
-            $("cvLabel").innerText = label;            
+        if (index % 2 == 0) {
+          cpLeft = createNestedCanvasPanelElement(clickedCanvas.id);
+          leftLabel = this.getAttribute("data-label");
+          otherIndex = index + 1;
+        } else {
+          cpRight = createNestedCanvasPanelElement(clickedCanvas.id);
+          rightLabel = this.getAttribute("data-label");
+          otherIndex = index - 1;
         }
-
-        function createNestedCanvasPanelElement(canvasId){
-            const cp = document.createElement("canvas-panel");
-            cp.setAttribute("nested", "true");
-            cp.setAttribute("canvas-id", canvasId);  
-            cp.setAttribute("manifest-id", manifest.id);  // not needed?
-            cp.vault = vault;  
-            return cp;
+        const otherThumb = document.querySelector(
+          `[data-index="${otherIndex}"]`
+        );
+        if (otherThumb) {
+          otherCanvas = vault.get(otherThumb.getAttribute("data-uri"));
+          cpOther = createNestedCanvasPanelElement(otherCanvas.id);
+          otherLabel = otherThumb.getAttribute("data-label");
         }
-     </script>
-</body>
+        offsetCanvas = clickedCanvas;
+        if (cpLeft) {
+          cpRight = cpOther;
+        } else {
+          cpLeft = cpOther;
+          if (otherCanvas) {
+            offsetCanvas = otherCanvas;
+          }
+        }
+        if (cpLeft) {
+          layout.appendChild(cpLeft);
+        }
+        if (cpRight) {
+          cpRight.setAttribute("x", offsetCanvas.width + 10);
+          layout.appendChild(cpRight);
+        }
+        let label;
+        if (leftLabel) {
+          label = `${leftLabel} | ${otherLabel}`;
+        } else {
+          label = `${otherLabel} | ${rightLabel}`;
+        }
+        $("cvLabel").innerText = label;
+      }
+
+      function createNestedCanvasPanelElement(canvasId) {
+        const cp = document.createElement("canvas-panel");
+        cp.setAttribute("nested", "true");
+        cp.setAttribute("canvas-id", canvasId);
+        cp.setAttribute("manifest-id", manifest.id); // not needed?
+        cp.vault = vault;
+        return cp;
+      }
+    </script>
+  </body>
 </html>

--- a/static/demos/common-features.html
+++ b/static/demos/common-features.html
@@ -1,70 +1,96 @@
 <html>
-<head>
+  <head>
     <title>Canvas Panel - Common features</title>
     <style>
-        #manifest { width: 50vw; }
-        #th { width:12vw; border-right: 1px solid #999; margin: 5px; float:left; height:90%; overflow-y:scroll; }        
-        #main { width:78vw; margin-top:30px; margin-left:10px; float:left; height:90%;} 
-        .tc { display: inline-block; padding:5px; cursor: pointer; }
-        #cp { height:100% }
+      #manifest {
+        width: 50vw;
+      }
+      #th {
+        width: 12vw;
+        border-right: 1px solid #999;
+        margin: 5px;
+        float: left;
+        height: 90%;
+        overflow-y: scroll;
+      }
+      #main {
+        width: 78vw;
+        margin-top: 30px;
+        margin-left: 10px;
+        float: left;
+        height: 90%;
+      }
+      .tc {
+        display: inline-block;
+        padding: 5px;
+        cursor: pointer;
+      }
+      #cp {
+        height: 100%;
+      }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
-</head>
-<body>
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
+  </head>
+  <body>
     <h1>A simple viewer using Canvas Panel</h1>
     <h2 id="manifestLabel"></h2>
-    <div>    
-        <input id="manifest" type="text" value="https://iiif.wellcomecollection.org/presentation/b18035723" />
-        <input id="go" type="button" value="Go" />
-    </div>    
-    
-    <div>    
-        <div id="th"></div>
-        <div id="main">
-            <canvas-panel id="cp" height="600"></canvas-panel> <!--height="95%" -->
-            <p id="cvLabel"></p>
-        </div>
+    <div>
+      <input
+        id="manifest"
+        type="text"
+        value="https://iiif.wellcomecollection.org/presentation/b18035723"
+      />
+      <input id="go" type="button" value="Go" />
     </div>
-    <script>    
 
-        function $(id) { return document.getElementById(id); }
-        const cp = $("cp"); 
-        const thumbHelper = VaultHelpers.createThumbnailHelper(cp.vault);
+    <div>
+      <div id="th"></div>
+      <div id="main">
+        <canvas-panel id="cp" height="600"></canvas-panel>
+        <!--height="95%" -->
+        <p id="cvLabel"></p>
+      </div>
+    </div>
+    <script>
+      function $(id) {
+        return document.getElementById(id);
+      }
+      const cp = $("cp");
+      const thumbHelper = IIIFHelpers.createThumbnailHelper(cp.vault);
 
-        async function loadManifest(){
-            const manifestUri = $("manifest").value;
-            if(manifestUri){
-                const manifest = await cp.vault.loadManifest(manifestUri);       
-                $("manifestLabel").innerText = VaultHelpers.getValue(manifest.label);      
-                let thumbsHtml = "";
-                // A real viewer could use <sequence-panel> for thumbnails, too.
-                // To keep this minimal we''' make thumbnail links by hand.
-                for(const canvasRef of cp.vault.get(manifest.items)){     
-                    const canvas = cp.vault.get(canvasRef);         
-                    const label = VaultHelpers.getValue(canvas.label);
-                    thumbsHtml += `<div class="tc">${label}<br/>`;
-                    thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" />`;
-                    thumbsHtml += '</div>';   
-                }
-                $('th').innerHTML = thumbsHtml;    
-                const thumbs = document.querySelectorAll('#th img');      
-                for(const thumb of thumbs){
-                    thumb.addEventListener('click', selectCanvas);
-                }  
-                thumbs[0].click();
-            }
+      async function loadManifest() {
+        const manifestUri = $("manifest").value;
+        if (manifestUri) {
+          const manifest = await cp.vault.loadManifest(manifestUri);
+          $("manifestLabel").innerText = IIIFHelpers.getValue(manifest.label);
+          let thumbsHtml = "";
+          // A real viewer could use <sequence-panel> for thumbnails, too.
+          // To keep this minimal we''' make thumbnail links by hand.
+          for (const canvasRef of cp.vault.get(manifest.items)) {
+            const canvas = cp.vault.get(canvasRef);
+            const label = IIIFHelpers.getValue(canvas.label);
+            thumbsHtml += `<div class="tc">${label}<br/>`;
+            thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" />`;
+            thumbsHtml += "</div>";
+          }
+          $("th").innerHTML = thumbsHtml;
+          const thumbs = document.querySelectorAll("#th img");
+          for (const thumb of thumbs) {
+            thumb.addEventListener("click", selectCanvas);
+          }
+          thumbs[0].click();
         }
+      }
 
-        $("go").addEventListener('click', loadManifest);
-        loadManifest();
+      $("go").addEventListener("click", loadManifest);
+      loadManifest();
 
-        function selectCanvas(){
-            const cvId = this.getAttribute("data-uri");
-            cp.setCanvas(cvId);
-            $("cvLabel").innerText = this.getAttribute("data-label");
-        }
-
-     </script>
-</body>
+      function selectCanvas() {
+        const cvId = this.getAttribute("data-uri");
+        cp.setCanvas(cvId);
+        $("cvLabel").innerText = this.getAttribute("data-label");
+      }
+    </script>
+  </body>
 </html>

--- a/static/demos/layouttest.html
+++ b/static/demos/layouttest.html
@@ -1,22 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Layout test</title>
 
     <script src="https://pkg.csb.dev/digirati-co-uk/iiif-canvas-panel/commit/b239c900/@digirati/canvas-panel-web-components/dist/bundle.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault@latest/dist/index.umd.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
-</head>
-<body>
-    
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
+  </head>
+  <body>
     <layout-container width="800" preset="zoom">
-        <image-service nested="true" src="https://iiif.wellcomecollection.org/image/b18035723_0010.JP2" x="0"></image-service> 
-        <image-service nested="true" src="https://iiif.wellcomecollection.org/image/b18035723_0011.JP2" x="2411"></image-service>
+      <image-service
+        nested="true"
+        src="https://iiif.wellcomecollection.org/image/b18035723_0010.JP2"
+        x="0"
+      ></image-service>
+      <image-service
+        nested="true"
+        src="https://iiif.wellcomecollection.org/image/b18035723_0011.JP2"
+        x="2411"
+      ></image-service>
     </layout-container>
-    
-
-</body>
+  </body>
 </html>

--- a/static/demos/old_bookreader.html
+++ b/static/demos/old_bookreader.html
@@ -1,173 +1,206 @@
 <html>
-<head>
+  <head>
     <title>Bookreader</title>
     <style>
-        #manifest { width: 50vw; }
-        #th { width:240px; border-right: 1px solid #999; margin: 5px; float:left; height:90%; overflow-y:scroll; }        
-        #main { width:72vw; margin-top:30px; margin-left:10px; float:left; height:90%;} 
-        .tc { display: inline-block; padding:5px; cursor: pointer; min-width: 100; }
-        #viewportContainer { height:80%; background-color: black; display: flex }
-        sequence-panel {
-            display: flex;
-            flex-direction: column;
-            flex: 1;
-            min-width: 0; /* Required for downsizing */
+      #manifest {
+        width: 50vw;
+      }
+      #th {
+        width: 240px;
+        border-right: 1px solid #999;
+        margin: 5px;
+        float: left;
+        height: 90%;
+        overflow-y: scroll;
+      }
+      #main {
+        width: 72vw;
+        margin-top: 30px;
+        margin-left: 10px;
+        float: left;
+        height: 90%;
+      }
+      .tc {
+        display: inline-block;
+        padding: 5px;
+        cursor: pointer;
+        min-width: 100;
+      }
+      #viewportContainer {
+        height: 80%;
+        background-color: black;
+        display: flex;
+      }
+      sequence-panel {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0; /* Required for downsizing */
 
-            --atlas-container-flex: 1 1 0px;
-            --atlas-background: #000;
-        }
+        --atlas-container-flex: 1 1 0px;
+        --atlas-background: #000;
+      }
 
-        /* #cp { height:100% } */
+      /* #cp { height:100% } */
     </style>
     <script src="https://pkg.csb.dev/digirati-co-uk/iiif-canvas-panel/commit/b239c900/@digirati/canvas-panel-web-components/dist/bundle.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault@latest/dist/index.umd.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
-</head>
-<body>
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
+  </head>
+  <body>
     <h1>A bookreader using Canvas Panel and Layout Container</h1>
     <h2 id="manifestLabel"></h2>
-    <div>    
-        <input id="manifest" type="text" value="https://iiif.wellcomecollection.org/presentation/b18035723" />
-        <input id="go" type="button" value="Go" />
-    </div>    
-    <div>    
-        <div id="th"></div>
-        <div id="main">
-            <div id="viewportContainer">
-
-            </div>
-            <p id="cvLabel"></p>
-        </div>
+    <div>
+      <input
+        id="manifest"
+        type="text"
+        value="https://iiif.wellcomecollection.org/presentation/b18035723"
+      />
+      <input id="go" type="button" value="Go" />
+    </div>
+    <div>
+      <div id="th"></div>
+      <div id="main">
+        <div id="viewportContainer"></div>
+        <p id="cvLabel"></p>
+      </div>
     </div>
 
-    <script>    
-        function $(id) { return document.getElementById(id); }
-        const vault = new IIIFVault.Vault();
-        const thumbHelper = VaultHelpers.createThumbnailHelper(vault);
-        let manifest;
+    <script>
+      function $(id) {
+        return document.getElementById(id);
+      }
+      const vault = new IIIFHelpers.Vault();
+      const thumbHelper = IIIFHelpers.createThumbnailHelper(vault);
+      let manifest;
 
-        async function loadManifest(){
-            const manifestUri = $("manifest").value;
-            if(manifestUri){
-                manifest = await vault.loadManifest(manifestUri);     
-                
-                const viewportContainer = $("viewportContainer");
-                viewportContainer.innerHTML = '';
-                // New component.
-                const sequencePanel = document.createElement('sequence-panel');
-                sequencePanel.vault = vault;
-                sequencePanel.setAttribute('manifest-id', manifestUri);
-                sequencePanel.setAttribute('margin', '20');
-                // sequencePanel.setAttribute('text-enabled', 'true');
-                // sequencePanel.setAttribute('text-selection-enabled', 'true');
-                viewportContainer.appendChild(sequencePanel);
-                
-                $("manifestLabel").innerText = VaultHelpers.getValue(manifest.label);      
-                let thumbsHtml = "";
-                let counter = 1;
-                // for brevity we will assume that the manifest is "paged", the viewingDirection is left-to-right.
-                thumbsHtml += '<div class="tc"></div>';
-                for(const canvasRef of vault.get(manifest.items)){  
-                    const canvas = vault.get(canvasRef);            
-                    const label = VaultHelpers.getValue(canvas.label);
-                    thumbsHtml += `<div class="tc">${label}<br/>`;
-                    thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" data-index="${counter}" />`;
-                    thumbsHtml += '</div>';   
-                    counter++;
-                }
-                $('th').innerHTML = thumbsHtml;    
-                const thumbs = document.querySelectorAll('#th img');      
-                for(const thumb of thumbs){
-                    // thumb.addEventListener('click', selectCanvas);
-                    thumb.addEventListener('click', () => {
-                        // Change the canvas.
-                        if (sequencePanel.sequence) {
-                            sequencePanel.sequence.setCurrentCanvasId(thumb.getAttribute('data-uri'));                        
-                        }
-                    });
-                }  
-                sequencePanel.addEventListener("sequence-change", () => {
-                    const sequence = sequencePanel.sequence; // reacquire
-                    const itemIndexes = sequence.sequence[sequence.currentSequenceIndex]; 
-                    const canvasRefs = itemIndexes.map(idx => sequence.items[idx]);
-                    const canvases = vault.get(canvasRefs);
-                    const labels = canvases.map(canvas => VaultHelpers.getValue(canvas.label));
-                    $("cvLabel").innerText = labels.join(" | ");  
-                });
-                thumbs[0].click();
-            }
+      async function loadManifest() {
+        const manifestUri = $("manifest").value;
+        if (manifestUri) {
+          manifest = await vault.loadManifest(manifestUri);
+
+          const viewportContainer = $("viewportContainer");
+          viewportContainer.innerHTML = "";
+          // New component.
+          const sequencePanel = document.createElement("sequence-panel");
+          sequencePanel.vault = vault;
+          sequencePanel.setAttribute("manifest-id", manifestUri);
+          sequencePanel.setAttribute("margin", "20");
+          // sequencePanel.setAttribute('text-enabled', 'true');
+          // sequencePanel.setAttribute('text-selection-enabled', 'true');
+          viewportContainer.appendChild(sequencePanel);
+
+          $("manifestLabel").innerText = IIIFHelpers.getValue(manifest.label);
+          let thumbsHtml = "";
+          let counter = 1;
+          // for brevity we will assume that the manifest is "paged", the viewingDirection is left-to-right.
+          thumbsHtml += '<div class="tc"></div>';
+          for (const canvasRef of vault.get(manifest.items)) {
+            const canvas = vault.get(canvasRef);
+            const label = IIIFHelpers.getValue(canvas.label);
+            thumbsHtml += `<div class="tc">${label}<br/>`;
+            thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" data-index="${counter}" />`;
+            thumbsHtml += "</div>";
+            counter++;
+          }
+          $("th").innerHTML = thumbsHtml;
+          const thumbs = document.querySelectorAll("#th img");
+          for (const thumb of thumbs) {
+            // thumb.addEventListener('click', selectCanvas);
+            thumb.addEventListener("click", () => {
+              // Change the canvas.
+              if (sequencePanel.sequence) {
+                sequencePanel.sequence.setCurrentCanvasId(
+                  thumb.getAttribute("data-uri")
+                );
+              }
+            });
+          }
+          sequencePanel.addEventListener("sequence-change", () => {
+            const sequence = sequencePanel.sequence; // reacquire
+            const itemIndexes =
+              sequence.sequence[sequence.currentSequenceIndex];
+            const canvasRefs = itemIndexes.map((idx) => sequence.items[idx]);
+            const canvases = vault.get(canvasRefs);
+            const labels = canvases.map((canvas) =>
+              IIIFHelpers.getValue(canvas.label)
+            );
+            $("cvLabel").innerText = labels.join(" | ");
+          });
+          thumbs[0].click();
         }
-        
-        $("go").addEventListener('click', loadManifest);
-        loadManifest();
-        
+      }
 
-        // Unused.
-        function selectCanvas(){
-            var clickedCanvas = vault.get(this.getAttribute("data-uri"));
-            const viewportContainer = $("viewportContainer");
-            // var layout = document.createElement("atlas-viewer");
-            var layout = document.createElement("sequence-panel");
-            layout.setAttribute("preset", "zoom");
-            layout.setAttribute("manifest-id", manif);
-            viewportContainer.replaceChildren();            
-            viewportContainer.appendChild(layout);
+      $("go").addEventListener("click", loadManifest);
+      loadManifest();
 
-            let leftCanvas, rightCanvas, otherCanvas;
-            let cpLeft, cpRight, cpOther;
-            let leftLabel, rightLabel, otherLabel;
+      // Unused.
+      function selectCanvas() {
+        var clickedCanvas = vault.get(this.getAttribute("data-uri"));
+        const viewportContainer = $("viewportContainer");
+        // var layout = document.createElement("atlas-viewer");
+        var layout = document.createElement("sequence-panel");
+        layout.setAttribute("preset", "zoom");
+        layout.setAttribute("manifest-id", manif);
+        viewportContainer.replaceChildren();
+        viewportContainer.appendChild(layout);
 
-            const index = parseInt(this.getAttribute("data-index"));
-            let otherIndex;
+        let leftCanvas, rightCanvas, otherCanvas;
+        let cpLeft, cpRight, cpOther;
+        let leftLabel, rightLabel, otherLabel;
 
-            if(index % 2 == 0){
-                cpLeft = createNestedCanvasPanelElement(clickedCanvas.id);           
-                leftLabel = this.getAttribute("data-label");
-                otherIndex = index + 1;             
-            } else {
-                cpRight = createNestedCanvasPanelElement(clickedCanvas.id);                         
-                rightLabel = this.getAttribute("data-label");
-                otherIndex = index - 1;  
-            }
-            const otherThumb = document.querySelector(`[data-index="${otherIndex}"]`);
-            if(otherThumb){
-                otherCanvas = vault.get(otherThumb.getAttribute("data-uri"));
-                cpOther = createNestedCanvasPanelElement(otherCanvas.id); 
-                otherLabel = otherThumb.getAttribute("data-label");
-            }
-            offsetCanvas = clickedCanvas;
-            if(cpLeft){
-                cpRight = cpOther;
-            } else {
-                cpLeft = cpOther;
-                if(otherCanvas){
-                    offsetCanvas = otherCanvas;
-                }
-            }
-            if(cpLeft){
-                layout.appendChild(cpLeft);
-            }
-            if(cpRight){
-                cpRight.setAttribute("x", offsetCanvas.width + 10);
-                layout.appendChild(cpRight);
-            }
-            let label;
-            if(leftLabel){
-                label = `${leftLabel} | ${otherLabel}`;
-            } else {
-                label = `${otherLabel} | ${rightLabel}`;
-            }
-            $("cvLabel").innerText = label;            
+        const index = parseInt(this.getAttribute("data-index"));
+        let otherIndex;
+
+        if (index % 2 == 0) {
+          cpLeft = createNestedCanvasPanelElement(clickedCanvas.id);
+          leftLabel = this.getAttribute("data-label");
+          otherIndex = index + 1;
+        } else {
+          cpRight = createNestedCanvasPanelElement(clickedCanvas.id);
+          rightLabel = this.getAttribute("data-label");
+          otherIndex = index - 1;
         }
-
-        function createNestedCanvasPanelElement(canvasId){
-            const cp = document.createElement("canvas-panel");
-            cp.setAttribute("nested", "true");
-            cp.setAttribute("canvas-id", canvasId);  
-            cp.setAttribute("manifest-id", manifest.id);  // not needed?
-            cp.vault = vault;  
-            return cp;
+        const otherThumb = document.querySelector(
+          `[data-index="${otherIndex}"]`
+        );
+        if (otherThumb) {
+          otherCanvas = vault.get(otherThumb.getAttribute("data-uri"));
+          cpOther = createNestedCanvasPanelElement(otherCanvas.id);
+          otherLabel = otherThumb.getAttribute("data-label");
         }
-     </script>
-</body>
+        offsetCanvas = clickedCanvas;
+        if (cpLeft) {
+          cpRight = cpOther;
+        } else {
+          cpLeft = cpOther;
+          if (otherCanvas) {
+            offsetCanvas = otherCanvas;
+          }
+        }
+        if (cpLeft) {
+          layout.appendChild(cpLeft);
+        }
+        if (cpRight) {
+          cpRight.setAttribute("x", offsetCanvas.width + 10);
+          layout.appendChild(cpRight);
+        }
+        let label;
+        if (leftLabel) {
+          label = `${leftLabel} | ${otherLabel}`;
+        } else {
+          label = `${otherLabel} | ${rightLabel}`;
+        }
+        $("cvLabel").innerText = label;
+      }
+
+      function createNestedCanvasPanelElement(canvasId) {
+        const cp = document.createElement("canvas-panel");
+        cp.setAttribute("nested", "true");
+        cp.setAttribute("canvas-id", canvasId);
+        cp.setAttribute("manifest-id", manifest.id); // not needed?
+        cp.vault = vault;
+        return cp;
+      }
+    </script>
+  </body>
 </html>

--- a/static/demos/simplest-viewer.html
+++ b/static/demos/simplest-viewer.html
@@ -1,69 +1,95 @@
 <html>
-<head>
+  <head>
     <title>Canvas Panel - simple</title>
     <style>
-        #manifest { width: 50vw; }
-        #th { width:12vw; border-right: 1px solid #999; margin: 5px; float:left; height:90%; overflow-y:scroll; }        
-        #main { width:78vw; margin-top:30px; margin-left:10px; float:left; height:90%;} 
-        .tc { display: inline-block; padding:5px; cursor: pointer; }
-        #cp { height:100% }
+      #manifest {
+        width: 50vw;
+      }
+      #th {
+        width: 12vw;
+        border-right: 1px solid #999;
+        margin: 5px;
+        float: left;
+        height: 90%;
+        overflow-y: scroll;
+      }
+      #main {
+        width: 78vw;
+        margin-top: 30px;
+        margin-left: 10px;
+        float: left;
+        height: 90%;
+      }
+      .tc {
+        display: inline-block;
+        padding: 5px;
+        cursor: pointer;
+      }
+      #cp {
+        height: 100%;
+      }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
-</head>
-<body>
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
+  </head>
+  <body>
     <h1>A simple viewer using Canvas Panel</h1>
     <h2 id="manifestLabel"></h2>
-    <div>    
-        <input id="manifest" type="text" value="https://iiif.wellcomecollection.org/presentation/b18035723" />
-        <input id="go" type="button" value="Go" />
-    </div>    
-    <div>    
-        <div id="th"></div>
-        <div id="main">
-            <canvas-panel id="cp" height="600"></canvas-panel> <!--height="95%" -->
-            <p id="cvLabel"></p>
-        </div>
+    <div>
+      <input
+        id="manifest"
+        type="text"
+        value="https://iiif.wellcomecollection.org/presentation/b18035723"
+      />
+      <input id="go" type="button" value="Go" />
     </div>
-    <script>    
+    <div>
+      <div id="th"></div>
+      <div id="main">
+        <canvas-panel id="cp" height="600"></canvas-panel>
+        <!--height="95%" -->
+        <p id="cvLabel"></p>
+      </div>
+    </div>
+    <script>
+      function $(id) {
+        return document.getElementById(id);
+      }
+      const cp = $("cp");
+      const thumbHelper = IIIFHelpers.createThumbnailHelper(cp.vault);
 
-        function $(id) { return document.getElementById(id); }
-        const cp = $("cp"); 
-        const thumbHelper = VaultHelpers.createThumbnailHelper(cp.vault);
-
-        async function loadManifest(){
-            const manifestUri = $("manifest").value;
-            if(manifestUri){
-                const manifest = await cp.vault.loadManifest(manifestUri);       
-                $("manifestLabel").innerText = VaultHelpers.getValue(manifest.label);      
-                let thumbsHtml = "";
-                // A real viewer could use <sequence-panel> for thumbnails, too.
-                // To keep this minimal we''' make thumbnail links by hand.
-                for(const canvasRef of cp.vault.get(manifest.items)){     
-                    const canvas = cp.vault.get(canvasRef);         
-                    const label = VaultHelpers.getValue(canvas.label);
-                    thumbsHtml += `<div class="tc">${label}<br/>`;
-                    thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" />`;
-                    thumbsHtml += '</div>';   
-                }
-                $('th').innerHTML = thumbsHtml;    
-                const thumbs = document.querySelectorAll('#th img');      
-                for(const thumb of thumbs){
-                    thumb.addEventListener('click', selectCanvas);
-                }  
-                thumbs[0].click();
-            }
+      async function loadManifest() {
+        const manifestUri = $("manifest").value;
+        if (manifestUri) {
+          const manifest = await cp.vault.loadManifest(manifestUri);
+          $("manifestLabel").innerText = IIIFHelpers.getValue(manifest.label);
+          let thumbsHtml = "";
+          // A real viewer could use <sequence-panel> for thumbnails, too.
+          // To keep this minimal we''' make thumbnail links by hand.
+          for (const canvasRef of cp.vault.get(manifest.items)) {
+            const canvas = cp.vault.get(canvasRef);
+            const label = IIIFHelpers.getValue(canvas.label);
+            thumbsHtml += `<div class="tc">${label}<br/>`;
+            thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" />`;
+            thumbsHtml += "</div>";
+          }
+          $("th").innerHTML = thumbsHtml;
+          const thumbs = document.querySelectorAll("#th img");
+          for (const thumb of thumbs) {
+            thumb.addEventListener("click", selectCanvas);
+          }
+          thumbs[0].click();
         }
+      }
 
-        $("go").addEventListener('click', loadManifest);
-        loadManifest();
+      $("go").addEventListener("click", loadManifest);
+      loadManifest();
 
-        function selectCanvas(){
-            const cvId = this.getAttribute("data-uri");
-            cp.setCanvas(cvId);
-            $("cvLabel").innerText = this.getAttribute("data-label");
-        }
-
-     </script>
-</body>
+      function selectCanvas() {
+        const cvId = this.getAttribute("data-uri");
+        cp.setCanvas(cvId);
+        $("cvLabel").innerText = this.getAttribute("data-label");
+      }
+    </script>
+  </body>
 </html>

--- a/static/demos/text-viewer-simple.html
+++ b/static/demos/text-viewer-simple.html
@@ -1,82 +1,112 @@
 <html>
-<head>
+  <head>
     <title>Text Viewer - simple</title>
     <style>
-        #manifest { width: 50vw; }
-        #th { width:12vw; border-right: 1px solid #999; margin: 5px; float:left; height:90%; overflow-y:scroll; }        
-        #main { width:78vw; margin-top:30px; margin-left:10px; float:left; height:90%;} 
-        .tc { display: inline-block; padding:5px; cursor: pointer; }
-        #cp { height:100% }
+      #manifest {
+        width: 50vw;
+      }
+      #th {
+        width: 12vw;
+        border-right: 1px solid #999;
+        margin: 5px;
+        float: left;
+        height: 90%;
+        overflow-y: scroll;
+      }
+      #main {
+        width: 78vw;
+        margin-top: 30px;
+        margin-left: 10px;
+        float: left;
+        height: 90%;
+      }
+      .tc {
+        display: inline-block;
+        padding: 5px;
+        cursor: pointer;
+      }
+      #cp {
+        height: 100%;
+      }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/@digirati/canvas-panel-web-components@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@iiif/vault-helpers@latest/dist/index.umd.js"></script>
-</head>
-<body>
+    <script src="https://cdn.jsdelivr.net/npm/@iiif/helpers@latest/dist/index.umd.js"></script>
+  </head>
+  <body>
     <h1>A simple viewer using Canvas Panel</h1>
     <h2 id="manifestLabel"></h2>
-    <div>    
-        <input id="manifest" type="text" value="https://iiif.wellcomecollection.org/presentation/b18035723" />
-        <input id="go" type="button" value="Go" />
-        
-        <br/>
-        <input id="toggleText" type="button" value="Enable text selection" data-mode="off">
-    </div>    
-    <div>    
-        <div id="th"></div>
-        <div id="main">
-            <canvas-panel id="cp" height="600" text-enabled="true"></canvas-panel>
-            <p id="cvLabel"></p>
-        </div>
+    <div>
+      <input
+        id="manifest"
+        type="text"
+        value="https://iiif.wellcomecollection.org/presentation/b18035723"
+      />
+      <input id="go" type="button" value="Go" />
+
+      <br />
+      <input
+        id="toggleText"
+        type="button"
+        value="Enable text selection"
+        data-mode="off"
+      />
     </div>
-    <script>    
+    <div>
+      <div id="th"></div>
+      <div id="main">
+        <canvas-panel id="cp" height="600" text-enabled="true"></canvas-panel>
+        <p id="cvLabel"></p>
+      </div>
+    </div>
+    <script>
+      function $(id) {
+        return document.getElementById(id);
+      }
+      const cp = $("cp");
+      const thumbHelper = IIIFHelpers.createThumbnailHelper(cp.vault);
 
-        function $(id) { return document.getElementById(id); }
-        const cp = $("cp"); 
-        const thumbHelper = VaultHelpers.createThumbnailHelper(cp.vault);
-
-        async function loadManifest(){
-            const manifestUri = $("manifest").value;
-            if(manifestUri){
-                const manifest = await cp.vault.loadManifest(manifestUri);       
-                $("manifestLabel").innerText = VaultHelpers.getValue(manifest.label);      
-                let thumbsHtml = "";
-                // A real viewer could use <sequence-panel> for thumbnails, too.
-                // To keep this minimal we''' make thumbnail links by hand.
-                for(const canvasRef of cp.vault.get(manifest.items)){     
-                    const canvas = cp.vault.get(canvasRef);         
-                    const label = VaultHelpers.getValue(canvas.label);
-                    thumbsHtml += `<div class="tc">${label}<br/>`;
-                    thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" />`;
-                    thumbsHtml += '</div>';   
-                }
-                $('th').innerHTML = thumbsHtml;    
-                const thumbs = document.querySelectorAll('#th img');      
-                for(const thumb of thumbs){
-                    thumb.addEventListener('click', selectCanvas);
-                }  
-                thumbs[0].click();
-            }
+      async function loadManifest() {
+        const manifestUri = $("manifest").value;
+        if (manifestUri) {
+          const manifest = await cp.vault.loadManifest(manifestUri);
+          $("manifestLabel").innerText = IIIFHelpers.getValue(manifest.label);
+          let thumbsHtml = "";
+          // A real viewer could use <sequence-panel> for thumbnails, too.
+          // To keep this minimal we''' make thumbnail links by hand.
+          for (const canvasRef of cp.vault.get(manifest.items)) {
+            const canvas = cp.vault.get(canvasRef);
+            const label = IIIFHelpers.getValue(canvas.label);
+            thumbsHtml += `<div class="tc">${label}<br/>`;
+            thumbsHtml += `<img data-uri="${canvas.id}" data-label="${label}" src="${canvas.thumbnail[0].id}" />`;
+            thumbsHtml += "</div>";
+          }
+          $("th").innerHTML = thumbsHtml;
+          const thumbs = document.querySelectorAll("#th img");
+          for (const thumb of thumbs) {
+            thumb.addEventListener("click", selectCanvas);
+          }
+          thumbs[0].click();
         }
+      }
 
-        $("go").addEventListener('click', loadManifest);
-        loadManifest();
+      $("go").addEventListener("click", loadManifest);
+      loadManifest();
 
-        function selectCanvas(){
-            const cvId = this.getAttribute("data-uri");
-            cp.setCanvas(cvId);
-            $("cvLabel").innerText = this.getAttribute("data-label");
+      function selectCanvas() {
+        const cvId = this.getAttribute("data-uri");
+        cp.setCanvas(cvId);
+        $("cvLabel").innerText = this.getAttribute("data-label");
+      }
+
+      $("toggleText").addEventListener("click", () => {
+        if (cp.getAttribute("text-selection-enabled") == "false") {
+          cp.disableTextSelection();
+          $("toggleText").value = "Enable text selection";
+        } else {
+          cp.enableTextSelection();
+          $("toggleText").value = "Disable text selection";
         }
-        
-        $("toggleText").addEventListener("click", () => {
-            if(cp.getAttribute("text-selection-enabled") == "false"){
-                cp.disableTextSelection();
-                $("toggleText").value = "Enable text selection";
-            } else {                
-                cp.enableTextSelection();
-                $("toggleText").value = "Disable text selection";
-            }
-        });
-
-     </script>
-</body>
+      });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
Summary of changes:
- `@iiif/vault` -> `@iiif/helpers`
- `@iiif/vault-helpers` -> `@iiif/helpers`
- `@atlas-viewer/atlas` bumped to v2.x (currently a PR branch)
- `@iiif/parser` bumped to v2.x
- `@iiif/presentation-3` bumped to v2.x
- `react-iiif-vault` bumped to v1.x


In practice this will mean a few updates to the sandboxes.

```
import { Vault } from '@iiif/vault';
import { createThumbnailHelper } from '@iiif/vault-helpers';
```

Is now:
```
import { Vault, createThumbnailHelper } from '@iiif/helpers';
```

A lot of changes under the hood, but no changes to the API. (Vault, React IIIF Vault or Helpers)