### PR TITLE
expose ContentState for CanvasPanel

### DIFF
--- a/docs/api-reference/1-methods.md
+++ b/docs/api-reference/1-methods.md
@@ -56,6 +56,7 @@ interface PublicAPI {
     withAtlas(callback: (rt: Runtime) => void);
     goHome(immediate = false);
     getZoom();
+    getContentState();
     getScaleInformation();
     goToTarget(
       target: {

--- a/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
+++ b/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
@@ -335,6 +335,15 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
         htmlComponent.setAttribute('choice-id', choiceIds.join(','));
       },
 
+      getPosition() {
+        return {
+          x: runtime.current?.x,
+          y: runtime.current?.y,
+          width: runtime.current?.width,
+          height: runtime.current?.height
+        }
+      },
+
       getMaxZoom() {
         return runtime.current?.maxScaleFactor || 1;
       },

--- a/packages/canvas-panel/src/hooks/use-register-public-api.ts
+++ b/packages/canvas-panel/src/hooks/use-register-public-api.ts
@@ -51,7 +51,7 @@ export type UseRegisterPublicApi = {
     getCanvasId(): string | undefined;
     getManifest(): ManifestNormalized | undefined;
     getManifestId(): string | undefined;
-
+    getPosition(): object | undefined;
     // Proposed helpers
     getDefaultChoiceIds(): string[];
     setDefaultChoiceIds(ids: string[] | ((prev: string[]) => string[])): void;

--- a/packages/canvas-panel/src/hooks/use-register-public-api.ts
+++ b/packages/canvas-panel/src/hooks/use-register-public-api.ts
@@ -51,7 +51,7 @@ export type UseRegisterPublicApi = {
     getCanvasId(): string | undefined;
     getManifest(): ManifestNormalized | undefined;
     getManifestId(): string | undefined;
-    getPosition(): object | undefined;
+    getContentState(): object | undefined;
     // Proposed helpers
     getDefaultChoiceIds(): string[];
     setDefaultChoiceIds(ids: string[] | ((prev: string[]) => string[])): void;

--- a/packages/canvas-panel/src/hooks/use-register-public-api.ts
+++ b/packages/canvas-panel/src/hooks/use-register-public-api.ts
@@ -52,6 +52,7 @@ export type UseRegisterPublicApi = {
     getManifest(): ManifestNormalized | undefined;
     getManifestId(): string | undefined;
     getContentState(): object | undefined;
+    getPosition(): object | undefined;
     // Proposed helpers
     getDefaultChoiceIds(): string[];
     setDefaultChoiceIds(ids: string[] | ((prev: string[]) => string[])): void;

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -148,15 +148,10 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
       },
 
       getContentState() {
-        const _x = runtime.current?.target[1];
-        const _y = runtime.current?.target[2];
-        const width = runtime.current?.target[3]; 
-        const height = runtime.current?.target[4];
-
         const _manifestId = manifestIdRef?.current ? manifestIdRef?.current : manifestId;
         const _canvasId = canvasIdRef?.current ? canvasIdRef?.current : canvasId;
         const contentState: ContentState = {
-          id: `${_canvasId}#xywh=${_x},${_y},${width},${height}`,
+          id: `${_canvasId}#xywh=${runtime.current?.x},${runtime.current?.y},${runtime.current?.width},${runtime.current?.height}`,
           type: 'Canvas',
           partOf: [{ id: _manifestId, type: 'Manifest' }],
         };
@@ -166,9 +161,18 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
           encodedContentState: serialiseContentState(contentState),
         };
 
-        console.log(runtime.current)
         return ContentStateEvent;
       },
+
+      getPosition() {
+        return {
+          x: runtime.current?.x,
+          y: runtime.current?.y,
+          width: runtime.current?.width,
+          height: runtime.current?.height
+        }
+      },
+
       getManifestId() {
         return manifestIdRef.current;
       },

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -147,6 +147,28 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
         return canvasIdRef.current;
       },
 
+      getContentState() {
+        const _x = runtime.current?.target[1];
+        const _y = runtime.current?.target[2];
+        const width = runtime.current?.target[3]; 
+        const height = runtime.current?.target[4];
+
+        const _manifestId = manifestIdRef?.current ? manifestIdRef?.current : manifestId;
+        const _canvasId = canvasIdRef?.current ? canvasIdRef?.current : canvasId;
+        const contentState: ContentState = {
+          id: `${_canvasId}#xywh=${_x},${_y},${width},${height}`,
+          type: 'Canvas',
+          partOf: [{ id: _manifestId, type: 'Manifest' }],
+        };
+        const ContentStateEvent = {
+          contentState,
+          normalisedContentState: normaliseContentState(contentState),
+          encodedContentState: serialiseContentState(contentState),
+        };
+
+        console.log(runtime.current)
+        return ContentStateEvent;
+      },
       getManifestId() {
         return manifestIdRef.current;
       },


### PR DESCRIPTION
One of the requirements we have for CanvasPanel is to be able to work dynamically with the content state.  To that end, it would be nice to be able to get the content state at any moment so we can tie that to significant actions and behaviors. This uses some of the logic that's available to expose the current content-state.

I'm sure I might be missing some logic here regarding sequences and choices... _but thinking those could be future work_