### PR TITLE
Expose ContentState for SequencePanel

### DIFF
--- a/packages/canvas-panel/src/helpers/content-state/content-state.ts
+++ b/packages/canvas-panel/src/helpers/content-state/content-state.ts
@@ -28,6 +28,20 @@ export type NormalisedContentState = {
   extensions: Record<string, any>;
 };
 
+/**
+ * if we set x or y to less than 0, then this is invalid for the web annotation (off canvas), so we set them to 0
+ *
+ * @param x the dimension information
+ *
+ * @returns {number}
+ */
+export function normaliseAxis(x?: number) {
+  if (x == undefined || x < 0) {
+    return 0;
+  }
+  return x;
+}
+
 type ValidationResponse = readonly [false, { reason?: string }] | readonly [true];
 
 export function validateContentState(annotation: ContentState, strict = false): ValidationResponse {

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -6,7 +6,7 @@ import { RegisterPublicApi, UseRegisterPublicApi } from '../hooks/use-register-p
 import { ViewCanvas } from '../components/ViewCanvas/ViewCanvas';
 import { ManifestLoader } from '../components/manifest-loader';
 import { parseBool, parseChoices, parseContentStateParameter } from '../helpers/parse-attributes';
-import { parseContentState, serialiseContentState } from '../helpers/content-state/content-state';
+import { normaliseAxis, parseContentState, serialiseContentState } from '../helpers/content-state/content-state';
 import { normaliseContentState } from '../helpers/content-state/content-state';
 import { GenericAtlasComponent } from '../types/generic-atlas-component';
 import { useGenericAtlasProps } from '../hooks/use-generic-atlas-props';
@@ -102,8 +102,9 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
   const onDrawBox = useCallback(
     (e: Projection) => {
       if (contentStateCallback) {
+
         const contentState: ContentState = {
-          id: `${canvasId}#xywh=${e.x},${e.y},${e.width},${e.height}`,
+          id: `${canvasId}#xywh=${normaliseAxis(e.x)},${normaliseAxis(e.y)},${e.width},${e.height}`,
           type: 'Canvas',
           partOf: [{ id: manifestId, type: 'Manifest' }],
         };

--- a/packages/canvas-panel/src/web-components/sequence-panel.tsx
+++ b/packages/canvas-panel/src/web-components/sequence-panel.tsx
@@ -108,17 +108,29 @@ export function SequencePanel(props: SequencePanelProps) {
 
         const _canvasId = sequenceInfo.items[sequenceInfo.sequence[sequenceInfo.currentSequenceIndex][0]].id;
 
+        // why do I have to cast this as any in order to get x/y/width/height(?)
+        // eslint-disable-next-line prefer-const
+        let { x, y, width, height } = runtime?.current as any;
+
+        // if we set x or y to less than 0, then normaliseContentState will turn it into an absolute value... this feels weird
+        if (x < 0) {
+          x = 0;
+        }
+        if (y < 0) {
+          y = 0;
+        }
+
         const contentState: ContentState = {
-          id: `${_canvasId}#xywh=${runtime.current?.x},${runtime.current?.y},${runtime.current?.width},${runtime.current?.height}`,
+          id: `${_canvasId}#xywh=${x},${y},${width},${height}`,
           type: 'Canvas',
           partOf: [{ id: _manifestId, type: 'Manifest' }],
         };
+
         const ContentStateEvent = {
           contentState,
           normalisedContentState: normaliseContentState(contentState),
           encodedContentState: serialiseContentState(contentState),
         };
-
         return ContentStateEvent;
       },
 
@@ -175,12 +187,18 @@ export function SequencePanel(props: SequencePanelProps) {
           const sequenceInfo = (el as any).sequence;
 
           sequenceInfo.setCurrentCanvasId(firstTarget.source.id);
-          // problem: if there's a zoom, once the page changes, the viewport info (zoom / x / y ) do not reset
           if (manifestSource) {
             setManifestId(manifestSource.id);
           }
           if (firstTarget.selector) {
-            setParsedTarget(firstTarget);
+            // weird that I have to cast here
+            const { x, y, width, height } = firstTarget.selector.spatial as any;
+            runtime?.current?.world.gotoRegion({
+              x,
+              y,
+              width,
+              height,
+            });
           }
         }
       }

--- a/packages/canvas-panel/src/web-components/sequence-panel.tsx
+++ b/packages/canvas-panel/src/web-components/sequence-panel.tsx
@@ -10,7 +10,7 @@ import { h } from 'preact';
 import { parseBool, parseNumber, parseContentStateParameter } from '../helpers/parse-attributes';
 import { useCallback, useLayoutEffect } from 'preact/compat';
 import { baseAttributes } from '../helpers/base-attributes';
-import { parseContentState, serialiseContentState } from '../helpers/content-state/content-state';
+import { normaliseAxis, parseContentState, serialiseContentState } from '../helpers/content-state/content-state';
 import { normaliseContentState } from '../helpers/content-state/content-state';
 import { useState } from 'preact/compat';
 
@@ -108,20 +108,11 @@ export function SequencePanel(props: SequencePanelProps) {
 
         const _canvasId = sequenceInfo.items[sequenceInfo.sequence[sequenceInfo.currentSequenceIndex][0]].id;
 
-        // why do I have to cast this as any in order to get x/y/width/height(?)
         // eslint-disable-next-line prefer-const
-        let { x, y, width, height } = runtime?.current as any;
-
-        // if we set x or y to less than 0, then normaliseContentState will turn it into an absolute value... this feels weird
-        if (x < 0) {
-          x = 0;
-        }
-        if (y < 0) {
-          y = 0;
-        }
+        let { x, y, width, height } = runtime?.current || {};
 
         const contentState: ContentState = {
-          id: `${_canvasId}#xywh=${x},${y},${width},${height}`,
+          id: `${_canvasId}#xywh=${normaliseAxis(x)},${normaliseAxis(y)},${width},${height}`,
           type: 'Canvas',
           partOf: [{ id: _manifestId, type: 'Manifest' }],
         };
@@ -190,9 +181,8 @@ export function SequencePanel(props: SequencePanelProps) {
           if (manifestSource) {
             setManifestId(manifestSource.id);
           }
-          if (firstTarget.selector) {
-            // weird that I have to cast here
-            const { x, y, width, height } = firstTarget.selector.spatial as any;
+          if (firstTarget.selector && firstTarget.selector.type === 'BoxSelector') {
+            const { x, y, width, height } = firstTarget.selector.spatial;
             runtime?.current?.world.gotoRegion({
               x,
               y,

--- a/packages/storybook/src/stories/canvas-panel.stories.tsx
+++ b/packages/storybook/src/stories/canvas-panel.stories.tsx
@@ -24,3 +24,14 @@ export const CanvasWithNavigator = () => {
   return <canvas-panel manifest-id="https://iiif.wellcomecollection.org/presentation/b18035723" canvas-id={canvases[0]} enable-navigator="true" />;
 
 }
+
+
+export const SequencePanel = () => {
+  {/* @ts-ignore */ }
+  return <>
+  <button onClick={() => document.querySelector("sequence-panel").sequence.previousCanvas()}>Prev</button>
+  <button onClick={() => document.querySelector("sequence-panel").sequence.nextCanvas()}>Next</button>
+  <sequence-panel manifest-id="https://iiif.wellcomecollection.org/presentation/b18035723" start-canvas={canvases[0]}  />;
+  </>
+
+}

--- a/packages/storybook/src/stories/canvas-panel.stories.tsx
+++ b/packages/storybook/src/stories/canvas-panel.stories.tsx
@@ -31,7 +31,7 @@ export const SequencePanel = () => {
   return <>
   <button onClick={() => document.querySelector("sequence-panel").sequence.previousCanvas()}>Prev</button>
   <button onClick={() => document.querySelector("sequence-panel").sequence.nextCanvas()}>Next</button>
-  <sequence-panel manifest-id="https://iiif.wellcomecollection.org/presentation/b18035723" start-canvas={canvases[0]}  />;
+  <sequence-panel manifest-id="https://iiif.wellcomecollection.org/presentation/b18035723" start-canvas={canvases[0]}  />
   </>
 
 }


### PR DESCRIPTION
This migrates the ‘setContentStateFromText` and `getContentState` logic from `canvas-panel` to ` sequence panel`.

It has two issues I could use some help with:
1. how to best access the current sequence information from within `sequence-panel`, asking for `webcomponent.current.sequence` feels like it’s going around the long way and casting `webcomponent.sequence` to `any` also feels weird.
2. When you get and set the contentState, the current ‘worldview’ (zoom / pan) persists across pages, is there a way to prevent this? I've tried adding various `keys` with the thought that refreshing the component might help, but not sure? @stephenwf  any ideas?