### PR TITLE
adjust choice event and management

### DIFF
--- a/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
+++ b/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
@@ -4,9 +4,7 @@ import {
   useResourceEvents,
   useRenderingStrategy,
   useThumbnail,
-  StrategyActions,
   useVault,
-  ChoiceDescription,
   useVaultSelector,
   useAnnotationPageManager,
   useManifest,
@@ -85,9 +83,12 @@ export function AtlasCanvas({
   const firstTextLines = hasTextLines ? pageTypes.pageMapping.supplementing[0] : null;
 
   useEffect(() => {
-    choiceEventChannel.on('onMakeChoice', (payload: { id: any; options: any }) => {
+    const unsubscribeOnMakeChoice = choiceEventChannel.on('onMakeChoice', (payload: { id: any; options: any }) => {
       actions.makeChoice(payload.id, payload.options);
     });
+    return () => {
+      unsubscribeOnMakeChoice();
+    };
   }, [actions]);
 
   useEffect(() => {

--- a/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
+++ b/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
@@ -25,6 +25,7 @@ import { RenderAudio } from '../RenderAudio/RenderAudio';
 import { RenderVideo } from '../RenderVideo/RenderVideo';
 import { RenderTextLines } from '../RenderTextLines/RenderTextLines';
 import { sortAnnotationPages } from '../../helpers/sort-annotation-pages';
+import { choiceEventChannel } from '../../helpers/eventbus';
 
 interface AtlasCanvasProps {
   x?: number;
@@ -34,10 +35,8 @@ interface AtlasCanvasProps {
   highlightCssClass?: string;
   debug?: boolean;
   annoMode?: boolean;
-  onChoiceChange?: (choice?: ChoiceDescription) => void;
   defaultChoices?: Array<{ id: string; opacity?: number }>;
   onCreated?: any;
-  registerActions?: (actions: StrategyActions) => void;
   isStatic?: boolean;
   textSelectionEnabled?: boolean;
   children?: any;
@@ -55,9 +54,7 @@ export function AtlasCanvas({
   onCreated,
   debug,
   virtualSizes,
-  onChoiceChange,
   highlightCssClass,
-  registerActions,
   defaultChoices,
   isStatic,
   textSelectionEnabled,
@@ -88,10 +85,10 @@ export function AtlasCanvas({
   const firstTextLines = hasTextLines ? pageTypes.pageMapping.supplementing[0] : null;
 
   useEffect(() => {
-    if (registerActions) {
-      registerActions(actions);
-    }
-  }, [strategy.annotations]);
+    choiceEventChannel.on('onMakeChoice', (payload: { id: any; options: any }) => {
+      actions.makeChoice(payload.id, payload.options);
+    });
+  }, [actions]);
 
   useEffect(() => {
     if (textEnabled) {
@@ -117,9 +114,7 @@ export function AtlasCanvas({
   }, [defaultChoices]);
 
   useLayoutEffect(() => {
-    if (onChoiceChange) {
-      onChoiceChange(choice);
-    }
+    choiceEventChannel.emit('onChoiceChange', { choice });
   }, [choice]);
 
   const thumbnail = useThumbnail({ maxWidth: 256, maxHeight: 256 });

--- a/packages/canvas-panel/src/components/RenderAllCanvases.tsx
+++ b/packages/canvas-panel/src/components/RenderAllCanvases.tsx
@@ -1,6 +1,5 @@
 import {
   CanvasContext as _CanvasContext,
-  ChoiceDescription,
   StrategyActions,
   useRange,
   useSimpleViewer,
@@ -11,6 +10,7 @@ import { SizeParameter } from '../helpers/size-parameter';
 import { h } from 'preact';
 import { Fragment, useEffect, useRef } from 'preact/compat';
 import { useRegisterPublicApi } from '../hooks/use-register-public-api';
+import { choiceEventChannel } from 'src/helpers/eventbus';
 
 const CanvasContext = _CanvasContext as any;
 
@@ -20,10 +20,8 @@ interface RenderAllCanvasesProps {
   highlightCssClass?: string;
   debug?: boolean;
   annoMode?: boolean;
-  onChoiceChange?: (choice?: ChoiceDescription) => void;
   defaultChoices?: Array<{ id: string; opacity?: number }>;
   onCreated?: any;
-  registerActions?: (actions: StrategyActions) => void;
   isStatic?: boolean;
   textSelectionEnabled?: boolean;
   children?: any;
@@ -56,6 +54,7 @@ export function RenderAllCanvases(props: RenderAllCanvasesProps) {
 
   useEffect(() => {
     if (webComponent.current) {
+      choiceEventChannel.emit('onResetSeen');
       webComponent.current.dispatchEvent(
         new CustomEvent('sequence-change', {
           detail: {

--- a/packages/canvas-panel/src/components/RenderAllCanvases.tsx
+++ b/packages/canvas-panel/src/components/RenderAllCanvases.tsx
@@ -1,16 +1,10 @@
-import {
-  CanvasContext as _CanvasContext,
-  StrategyActions,
-  useRange,
-  useSimpleViewer,
-  useVisibleCanvases,
-} from 'react-iiif-vault';
+import { CanvasContext as _CanvasContext, useRange, useSimpleViewer, useVisibleCanvases } from 'react-iiif-vault';
 import { AtlasCanvas } from './AtlasCanvas/AtlasCanvas';
 import { SizeParameter } from '../helpers/size-parameter';
 import { h } from 'preact';
 import { Fragment, useEffect, useRef } from 'preact/compat';
 import { useRegisterPublicApi } from '../hooks/use-register-public-api';
-import { choiceEventChannel } from 'src/helpers/eventbus';
+import { choiceEventChannel } from '../helpers/eventbus';
 
 const CanvasContext = _CanvasContext as any;
 

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
@@ -27,7 +27,7 @@ export function ViewCanvas(props: ViewCanvasProps) {
   const canvas = useCanvas();
   const manifest = useManifest();
   const manager = useAnnotationPageManager(manifest?.id || canvas?.id);
-  const actions = useRef<StrategyActions>();
+  const actions = useRef<StrategyActions[]>([]);
   const [annoMode, setAnnoMode] = useState(false);
   const aspectRatio =
     !props.displayOptions.viewport && canvas
@@ -44,10 +44,9 @@ export function ViewCanvas(props: ViewCanvasProps) {
     if (!(el as any).annotationPageManager) {
       (el as any).annotationPageManager = {};
     }
-
     (el as any).makeChoice = (id: string, options: any) => {
       if (actions.current) {
-        actions.current.makeChoice(id, options);
+        actions.current.forEach((action) => action.makeChoice(id, options));
       }
     };
 
@@ -135,7 +134,10 @@ export function ViewCanvas(props: ViewCanvasProps) {
           annoMode={annoMode}
           defaultChoices={props.defaultChoices}
           registerActions={(newActions) => {
-            actions.current = newActions;
+            if (actions.current) {
+              // note this will end up with lots of listeners... even if the component is destroyed
+              actions.current.push(newActions);
+            }
           }}
           disableThumbnail={props.disableThumbnail}
           skipSizes={props.skipSizes}

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
@@ -10,7 +10,6 @@ import {
   useAnnotationPageManager,
   useManifest,
   useVault,
-  StrategyActions,
 } from 'react-iiif-vault';
 import { useRegisterPublicApi } from '../../hooks/use-register-public-api';
 import { useLayoutEffect, useMemo, useRef, useState } from 'preact/compat';
@@ -28,7 +27,6 @@ export function ViewCanvas(props: ViewCanvasProps) {
   const canvas = useCanvas();
   const manifest = useManifest();
   const manager = useAnnotationPageManager(manifest?.id || canvas?.id);
-  const actions = useRef<StrategyActions[]>([]);
   const [annoMode, setAnnoMode] = useState(false);
   const aspectRatio =
     !props.displayOptions.viewport && canvas

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
@@ -19,6 +19,7 @@ import { ErrorFallback } from '../ErrorFallback/ErrorFallback';
 import { targetToPixels } from '../../helpers/target-to-pixels';
 import { RenderAllCanvases } from '../RenderAllCanvases';
 
+
 const ErrorBoundary = _ErrorBoundary as any;
 
 export function ViewCanvas(props: ViewCanvasProps) {
@@ -44,11 +45,6 @@ export function ViewCanvas(props: ViewCanvasProps) {
     if (!(el as any).annotationPageManager) {
       (el as any).annotationPageManager = {};
     }
-    (el as any).makeChoice = (id: string, options: any) => {
-      if (actions.current) {
-        actions.current.forEach((action) => action.makeChoice(id, options));
-      }
-    };
 
     // Update?
     (el as any).annotationPageManager.availablePageIds = manager.availablePageIds;
@@ -129,16 +125,9 @@ export function ViewCanvas(props: ViewCanvasProps) {
           debug={props.debug}
           virtualSizes={props.virtualSizes}
           highlight={props.highlight}
-          onChoiceChange={props.onChoiceChange}
           highlightCssClass={props.highlightCssClass}
           annoMode={annoMode}
           defaultChoices={props.defaultChoices}
-          registerActions={(newActions) => {
-            if (actions.current) {
-              // note this will end up with lots of listeners... even if the component is destroyed
-              actions.current.push(newActions);
-            }
-          }}
           disableThumbnail={props.disableThumbnail}
           skipSizes={props.skipSizes}
           onCreated={(e: any) => {

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
@@ -20,7 +20,6 @@ export type ViewCanvasProps = {
   followAnnotations?: boolean;
   virtualSizes: SizeParameter[];
   displayOptions: AtlasDisplayOptions;
-  onChoiceChange?: (choice?: ChoiceDescription) => void;
   children?: any;
   debug?: boolean;
   mode?: 'sketch' | 'explore';

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
@@ -1,5 +1,5 @@
 import { AtlasProps } from '@atlas-viewer/atlas';
-import { ChoiceDescription, ParsedSelector } from 'react-iiif-vault';
+import { ParsedSelector } from 'react-iiif-vault';
 import { SizeParameter } from '../../helpers/size-parameter';
 
 export type AtlasDisplayOptions = AtlasProps & {

--- a/packages/canvas-panel/src/helpers/eventbus.ts
+++ b/packages/canvas-panel/src/helpers/eventbus.ts
@@ -1,0 +1,65 @@
+import { ChoiceDescription } from 'react-iiif-vault/*';
+
+type EventKey = string | symbol;
+type EventHandler<T = any> = (payload: T) => void;
+type EventMap = Record<EventKey, EventHandler>;
+type Bus<E> = Record<keyof E, E[keyof E][]>;
+
+interface EventBus<T extends EventMap> {
+  on<Key extends keyof T>(key: Key, handler: T[Key]): () => void;
+  off<Key extends keyof T>(key: Key, handler: T[Key]): void;
+  once<Key extends keyof T>(key: Key, handler: T[Key]): void;
+  emit<Key extends keyof T>(key: Key, ...payload: Parameters<T[Key]>): void;
+}
+
+interface EventBusConfig {
+  onError: (...params: any[]) => void;
+}
+
+export const choiceEventChannel = eventbus<{
+  onMakeChoice: (payload: { id: string; options: any }) => void;
+  onChoiceChange: (payload: { choice?: ChoiceDescription }) => void;
+  onResetSeen: () => void;
+}>();
+
+export function eventbus<E extends EventMap>(config?: EventBusConfig): EventBus<E> {
+  const bus: Partial<Bus<E>> = {};
+
+  const on: EventBus<E>['on'] = (key, handler) => {
+    if (bus[key] === undefined) {
+      bus[key] = [];
+    }
+    bus[key]?.push(handler);
+
+    return () => {
+      off(key, handler);
+    };
+  };
+
+  const off: EventBus<E>['off'] = (key, handler) => {
+    const index = bus[key]?.indexOf(handler) ?? -1;
+    bus[key]?.splice(index >>> 0, 1);
+  };
+
+  const once: EventBus<E>['once'] = (key, handler) => {
+    const handleOnce = (payload: Parameters<typeof handler>) => {
+      handler(payload);
+      // TODO: find out a better way to type `handleOnce`
+      off(key, handleOnce as typeof handler);
+    };
+
+    on(key, handleOnce as typeof handler);
+  };
+
+  const emit: EventBus<E>['emit'] = (key, payload) => {
+    bus[key]?.forEach((fn) => {
+      try {
+        fn(payload);
+      } catch (e) {
+        config?.onError(e);
+      }
+    });
+  };
+
+  return { on, off, once, emit };
+}

--- a/packages/canvas-panel/src/helpers/eventbus.ts
+++ b/packages/canvas-panel/src/helpers/eventbus.ts
@@ -1,4 +1,4 @@
-import { ChoiceDescription } from 'react-iiif-vault/*';
+import { ChoiceDescription } from 'react-iiif-vault';
 
 type EventKey = string | symbol;
 type EventHandler<T = any> = (payload: T) => void;
@@ -17,8 +17,25 @@ interface EventBusConfig {
 }
 
 export const choiceEventChannel = eventbus<{
+  /**
+   * When the `makeChoice` api is called
+   *
+   * @param payload - the id and options for the choice
+   *
+   */
   onMakeChoice: (payload: { id: string; options: any }) => void;
+  /**
+   * When the system identifies that a choice is available
+   *
+   * @param payload - the id and options for the choice
+   *
+   */
   onChoiceChange: (payload: { choice?: ChoiceDescription }) => void;
+  /**
+   * When a canvas is changed, or a sequence is changed, this signals that
+   * the current set of choices should be reset
+   *
+   */
   onResetSeen: () => void;
 }>();
 

--- a/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
+++ b/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
@@ -2,7 +2,7 @@ import { GenericAtlasComponent } from '../types/generic-atlas-component';
 import { usePresetConfig } from './use-preset-config';
 import { Ref, useLayoutEffect, useMemo, useRef, useState } from 'preact/compat';
 import { useImageServiceLoader, useExistingVault, ChoiceDescription } from 'react-iiif-vault';
-import { BoxStyle, Runtime, AtlasProps, Preset, easingFunctions } from '@atlas-viewer/atlas';
+import { BoxStyle, Runtime, AtlasProps, easingFunctions } from '@atlas-viewer/atlas';
 import { useSyncedState } from './use-synced-state';
 import {
   parseBool,
@@ -17,7 +17,7 @@ import { ImageCandidateRequest } from '@atlas-viewer/iiif-image-api';
 import { createEventsHelper, createStylesHelper, createThumbnailHelper } from '@iiif/vault-helpers';
 import { useEffect } from 'preact/compat';
 import { globalVault } from '@iiif/vault';
-import { choiceEventChannel, eventbus } from '../helpers/eventbus';
+import { choiceEventChannel } from '../helpers/eventbus';
 
 export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtlasComponent<T>) {
   const webComponent = useRef<HTMLElement>();
@@ -147,40 +147,50 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
 
     return -1;
   }
+
   const seenChoices = useRef<object>({});
-  choiceEventChannel.on('onResetSeen', () => {
-    seenChoices.current = {};
-  });
 
-  choiceEventChannel.on('onChoiceChange', (payload: { choice?: ChoiceDescription }) => {
-    const choice = payload?.choice;
-    // sort the choices by ID in order to help with de-duping
-    if (webComponent?.current && choice?.items) {
-      // sort the keys by id first to make a consistent order
-      const items: any[] = choice.items as any[];
-      (items as any[]).sort((a, b) => {
-        if (a.id < b.id) {
-          return -1;
-        }
-        if (a.id > b.id) {
-          return 1;
-        }
-        return 0;
-      });
+  useEffect(() => {
+    const unsubscribeOnResetSeen = choiceEventChannel.on('onResetSeen', () => {
+      seenChoices.current = {};
+    });
 
-      const key: string = items.map((item) => item.id).join('');
-      const value: string = items.map((item) => item.selected).join('');
-      // if the key is defined & set to the value, then skip firing again
-      if ((seenChoices.current as any)[key] && (seenChoices.current as any)[key] == value) {
-        return;
+    const onChoiceChange = (payload: { choice?: ChoiceDescription }) => {
+      const choice = payload.choice;
+      // sort the choices by ID in order to help with de-duping
+      if (webComponent?.current && choice && choice.items) {
+        // sort the keys by id first to make a consistent order
+        const items: any[] = choice.items as any[];
+        (items as any[]).sort((a, b) => {
+          if (a.id < b.id) {
+            return -1;
+          }
+          if (a.id > b.id) {
+            return 1;
+          }
+          return 0;
+        });
+
+        const key: string = items.map((item) => item.id).join('');
+        const value: string = items.map((item) => item.selected).join('');
+        // if the key is defined & set to the value, then skip firing again
+        if ((seenChoices.current as any)[key] && (seenChoices.current as any)[key] == value) {
+          return;
+        }
+        // otherwise fire again
+        (seenChoices.current as any)[key] = value;
+        // move this outside the IF if we want to fire on every page
+
+        webComponent.current.dispatchEvent(new CustomEvent('choice', { detail: { choice } }));
       }
-      // otherwise fire again
-      (seenChoices.current as any)[key] = value;
-      // move this outside the IF if we want to fire on every page
+    };
+    const unsubscribeOnChoiceChange = choiceEventChannel.on('onChoiceChange', onChoiceChange);
 
-      webComponent.current.dispatchEvent(new CustomEvent('choice', { detail: { choice } }));
-    }
-  });
+    return () => {
+      unsubscribeOnResetSeen();
+      unsubscribeOnChoiceChange();
+    };
+  }, []);
 
   // fire a 'world-ready' event when we have a scale factor which is not undefined and not 1
   useEffect(() => {

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -17,7 +17,7 @@ import { ContentStateCallback, ContentStateEvent } from '../types/content-state'
 import { DrawBox, easingFunctions, Projection } from '@atlas-viewer/atlas';
 import { ContentState } from '@iiif/vault-helpers';
 import { baseAttributes } from '../helpers/base-attributes';
-import { choiceEventChannel } from 'src/helpers/eventbus';
+import { choiceEventChannel } from '../helpers/eventbus';
 
 export type CanvasPanelProps = GenericAtlasComponent<
   {

--- a/packages/canvas-panel/src/web-components/sequence-panel.tsx
+++ b/packages/canvas-panel/src/web-components/sequence-panel.tsx
@@ -1,7 +1,7 @@
 import register from '../library/preact-custom-element';
 import { GenericAtlasComponent } from '../types/generic-atlas-component';
 import { useGenericAtlasProps } from '../hooks/use-generic-atlas-props';
-import { ChoiceDescription, SimpleViewerProvider, SingleChoice, VaultProvider } from 'react-iiif-vault';
+import { SimpleViewerProvider, VaultProvider } from 'react-iiif-vault';
 import { ContentState } from '@iiif/vault-helpers';
 import { ViewCanvas } from '../components/ViewCanvas/ViewCanvas';
 import { RegisterPublicApi } from '../hooks/use-register-public-api';
@@ -82,41 +82,6 @@ export function SequencePanel(props: SequencePanelProps) {
     unknownContentState && unknownContentState.type === 'remote-content-state' ? unknownContentState.id : null;
   const [error, setError] = useState<Error | null>();
   const [skipSizes] = useProp('skipSizes', { parse: parseBool, defaultValue: false });
-
-  const seenChoices = useRef<object>({});
-  const currentSequenceIndex = useRef<number>();
-
-  const onChoiceChange = useCallback((choice?: ChoiceDescription) => {
-    // sort the choices by ID in order to help with de-duping
-    if (currentSequenceIndex.current != (webComponent?.current as any).sequence?.currentSequenceIndex) {
-      currentSequenceIndex.current = (webComponent?.current as any).sequence?.currentSequenceIndex;
-      seenChoices.current = {};
-    }
-    if (webComponent.current && choice?.items) {
-      // sort the keys by id first to make a consistent order
-      const items: any[] = choice.items as any[];
-      (items as any[]).sort((a, b) => {
-        if (a.id < b.id) {
-          return -1;
-        }
-        if (a.id > b.id) {
-          return 1;
-        }
-        return 0;
-      });
-
-      const key: string = items.map((item) => item.id).join('');
-      const value: string = items.map((item) => item.selected).join('');
-      // if the key is defined & set to the value, then skip firing again
-      if ((seenChoices.current as any)[key] && (seenChoices.current as any)[key] == value) {
-        return;
-      }
-      // otherwise fire again
-      (seenChoices.current as any)[key] = value;
-      // move this outside the IF if we want to fire on every page
-      webComponent.current.dispatchEvent(new CustomEvent('choice', { detail: { choice } }));
-    }
-  }, []);
 
   useRegisterWebComponentApi((htmlComponent: HTMLElement) => {
     return {
@@ -248,7 +213,6 @@ export function SequencePanel(props: SequencePanelProps) {
               key={`${startCanvas}-${viewport ? 'v1' : 'v0'}`}
               interactive={interactive}
               followAnnotations={followAnnotations}
-              onChoiceChange={onChoiceChange}
               className={className}
               highlight={highlight}
               debug={debug}

--- a/packages/canvas-panel/src/web-components/sequence-panel.tsx
+++ b/packages/canvas-panel/src/web-components/sequence-panel.tsx
@@ -8,11 +8,10 @@ import { RegisterPublicApi } from '../hooks/use-register-public-api';
 import { VirtualAnnotationProvider } from '../hooks/use-virtual-annotation-page-context';
 import { h } from 'preact';
 import { parseBool, parseNumber, parseContentStateParameter } from '../helpers/parse-attributes';
-import { useCallback, useLayoutEffect } from 'preact/compat';
+import { useState, useLayoutEffect } from 'preact/compat';
 import { baseAttributes } from '../helpers/base-attributes';
 import { normaliseAxis, parseContentState, serialiseContentState } from '../helpers/content-state/content-state';
 import { normaliseContentState } from '../helpers/content-state/content-state';
-import { useState, useRef, useEffect } from 'preact/compat';
 
 export type SequencePanelProps = GenericAtlasComponent<{
   manifestId: string;

--- a/packages/storybook/src/stories/canvas-panel.stories.tsx
+++ b/packages/storybook/src/stories/canvas-panel.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { action } from '@storybook/addon-actions';
 
 export default {title: 'Canvas Panel'}
@@ -186,3 +186,98 @@ export const CanvasWithContentState = () => {
 
 }
 
+
+
+const bayard="https://gist.githubusercontent.com/danieltbrennan/183d6cbb0948948413394cf116e5844a/raw/11fdda729f0c2960ee1d971902cdf0badd7f31df/bayard_w_choices.json"
+
+export const MakingChoice = () => {
+  const viewer = useRef()
+  const [canvases, setCanvses] = useState(['']);
+  const [cvindex, setCvindex] = useState(0);
+  const [choices, setChoices] = useState<any[]>([]);
+  let currentCanvasIndex = 0;
+
+  let newChoices = new Set<any>();
+  const makeChoice = (e) => {
+    viewer.current.makeChoice(e.target.value);
+    action('makeChoice')(e.target.value);
+  }
+
+  useEffect(() => {
+    clearChoiceState();
+  }, [cvindex]);
+  function clearChoiceState() {
+      choices.length = 0;
+      setChoices([]);
+      newChoices.clear();
+  }
+  const handleChoice = (e) => {
+
+    if (currentCanvasIndex != cvindex) {
+      console.log('resetting', currentCanvasIndex, cvindex);
+      currentCanvasIndex = cvindex;
+      clearChoiceState();
+    } else {
+      choices.forEach(opt => { 
+        newChoices.add(opt);
+      });
+
+    }
+    action(e.type)((e as any).detail);
+    if (e.detail?.choice?.type == "single-choice") {
+      const groupkey = e.detail.choice.items[0].id + '-' + e.detail.choice.items[1].id;
+      newChoices.forEach(choice => {
+        if (choice.groupkey == groupkey) {
+          newChoices.delete(choice);
+        }
+      })
+      e.detail.choice.items.map(item => {
+        newChoices.add({ id: item.id, groupkey : groupkey, label: item.label.en[0] , selected: item.selected});
+      });
+
+      const choiceList = Array.from(newChoices).sort((a, b) => {
+        if (a.groupkey < b.groupkey) {
+          return -1;
+        }
+        if (a.groupkey > b.groupkey) {
+          return 1;
+        }
+        return 0;
+      })
+
+      setChoices(choiceList);
+    }
+  };
+
+
+  useEffect(() => { 
+    viewer.current.addEventListener('choice', handleChoice)
+    viewer.current.vault.loadManifest(bayard).then((_manifest) => {
+      setCanvses(_manifest.items.map(item => item.id));
+    })
+
+
+    return () => viewer.current.removeEventListener('choice', handleChoice)
+
+  }, [document.querySelector(selector) !== undefined]);
+
+
+
+  return <>
+    <div>
+      <button onClick={()=>setCvindex(c => (cvindex - 1) % canvases.length)}>Prev Canvas</button>
+      <button onClick={() => setCvindex(c => (cvindex + 1) % canvases.length)}>Next Canvas</button>
+
+      <label htmlFor="choices">Choices: </label>
+        {choices.map(item => (
+          <label>
+          <input type='radio' key={item.id} checked={item.selected} onChange={makeChoice} name={item.groupkey} value={item.id} ></input>
+          { item.label} ({String(item.selected)})</label>
+        )
+        )}
+    
+     {/* @ts-ignore */ }
+      <canvas-panel ref={viewer} manifest-id={bayard} skip-sizes='true' canvas-id={canvases[Math.abs(cvindex)]  } />
+      </div>
+    </>
+}

--- a/packages/storybook/src/stories/sequence-panel.stories.tsx
+++ b/packages/storybook/src/stories/sequence-panel.stories.tsx
@@ -66,7 +66,6 @@ const bayard="https://gist.githubusercontent.com/danieltbrennan/183d6cbb09489484
 
 export const MakingChoice = () => {
   const viewer = useRef()
-  const [toggle, setToggle] = useState();
   const [choices, setChoices] = useState<any[]>([]);
   let currentSequenceIndex = 0;
 
@@ -96,7 +95,6 @@ export const MakingChoice = () => {
     action(e.type)((e as any).detail);
     if (e.detail?.choice?.type == "single-choice") {
       const groupkey = e.detail.choice.items[0].id + '-' + e.detail.choice.items[1].id;
-      console.log(groupkey);
       newChoices.forEach(choice => {
         if (choice.groupkey == groupkey) {
           newChoices.delete(choice);
@@ -135,20 +133,14 @@ export const MakingChoice = () => {
     <button onClick={() => viewer.current.sequence.setCurrentCanvasIndex(11)}>Go to: Canvas Index 11</button>
     <button onClick={() => viewer.current.sequence.previousCanvas()}>Prev</button>
     <button onClick={() => viewer.current.sequence.nextCanvas()}>Next</button>
-    <button onClick={() => {
-      setToggle(!toggle);
-      viewer.current.makeChoice(choices.current?.[toggle ? 1 : 0])
-    }
-  }>Toggle Current Choice</button>
       
-    <label htmlFor="choices">All choice ids for canvas index 11: </label>
+    <label htmlFor="choices">Choices: </label>
         {choices.map(item => (
           <label>
           <input type='radio' key={item.id} checked={item.selected} onChange={makeChoice} name={item.groupkey} value={item.id} ></input>
           { item.label} ({String(item.selected)})</label>
         )
         )}
-    {JSON.stringify(choices)}
     
      {/* @ts-ignore */ }
       <sequence-panel ref={viewer} manifest-id={bayard} />

--- a/packages/storybook/src/stories/sequence-panel.stories.tsx
+++ b/packages/storybook/src/stories/sequence-panel.stories.tsx
@@ -80,6 +80,9 @@ export const MakingChoice = () => {
       setChoices([]);
       newChoices.clear();
   }
+  const handleSequenceChange = (e) => {
+    clearChoiceState();
+  }
   const handleChoice = (e) => {
 
     if (currentSequenceIndex != viewer.current.sequence.currentSequenceIndex) {
@@ -121,6 +124,7 @@ export const MakingChoice = () => {
 
   useEffect(() => { 
     viewer.current.addEventListener('choice', handleChoice)
+    viewer.current.addEventListener('sequence-change', handleSequenceChange);
     return () => viewer.current.removeEventListener('choice', handleChoice)
 
   }, [document.querySelector(selector) !== undefined]);


### PR DESCRIPTION
This builds on @bulbil's story and this tries to fix a number of issues we’re seeing with choices:
1. choice events are firing multiple times with no change other than the order of the options changing
2. `makeChoice` is not being called on all canvases that might have that choice

Questions:
- if a canvas doesn't have any choices, should it fire a 'choice' event?
- how best to manage references, when dealing with AtlasViews that have been destroyed _(see comments)_
- an example to test choice for a non book style canvas