### PR TITLE
Added "home-cover" property.

### DIFF
--- a/docs/api-reference/1-json-api.mdx
+++ b/docs/api-reference/1-json-api.mdx
@@ -2,8 +2,8 @@
 sidebar_position: 1
 ---
 
-import presetSandbox from '@site/sandboxes/custom-preset.csb/_load';
-import { Sandbox } from '@site/Sandbox';
+import presetSandbox from "@site/sandboxes/custom-preset.csb/_load";
+import { Sandbox } from "@site/Sandbox";
 
 # Attributes
 
@@ -11,34 +11,40 @@ import { Sandbox } from '@site/Sandbox';
 
 ### width
 
-The width of the component, in pixels. 
-See [Styling](../examples/styling) for different ways of using Canvas Panel in layouts.
+The width of the component, in pixels. See [Styling](../examples/styling) for
+different ways of using Canvas Panel in layouts.
 
 ### height
 
-The height of the component, in pixels. 
-See [Styling](../examples/styling) for different ways of using Canvas Panel in layouts.
+The height of the component, in pixels. See [Styling](../examples/styling) for
+different ways of using Canvas Panel in layouts.
 
-:::tip
-You can also make the viewers grow to fit their container [using flexbox](../examples/show-a-canvas#flexbox-and-styling). 
-:::
+:::tip You can also make the viewers grow to fit their container
+[using flexbox](../examples/show-a-canvas#flexbox-and-styling). :::
 
 ### region
 
-Uses the IIIF syntax for a region of the canvas or image service. In zoom mode, the user can move out of this region after loading, but in other modes, it defines the rendered image.
+Uses the IIIF syntax for a region of the canvas or image service. In zoom mode,
+the user can move out of this region after loading, but in other modes, it
+defines the rendered image.
 
 ```html
 <canvas-panel region="1000,1200,900,1340">
-<canvas-panel region="pct:20,20,27.95,33.33">
+  <canvas-panel region="pct:20,20,27.95,33.33"></canvas-panel
+></canvas-panel>
 ```
 
 ### atlas-mode
 
 ```html
-<canvas-panel atlas-mode="explore"><!-- the default -->
-<canvas-panel atlas-mode="sketch">
+<canvas-panel atlas-mode="explore"
+  ><!-- the default -->
+  <canvas-panel atlas-mode="sketch"></canvas-panel
+></canvas-panel>
 ```
-In the default `explore` mode, dragging and panning actions move the canvas within the viewport.
+
+In the default `explore` mode, dragging and panning actions move the canvas
+within the viewport.
 
 In `sketch` mode, you can do the same _but have to hold down the space bar_.
 
@@ -46,58 +52,62 @@ This allows drawing functions to take over.
 
 ### preferred-formats
 
-:::caution
-This is an upcoming feature and may not use your preferred format chosen and default to `.jpg`
-:::
+:::caution This is an upcoming feature and may not use your preferred format
+chosen and default to `.jpg` :::
 
-
-Tell canvas panel to favour one or more formats when it constructs requests to image services - potentially overriding the service's own `preferredFormats` property.
+Tell canvas panel to favour one or more formats when it constructs requests to
+image services - potentially overriding the service's own `preferredFormats`
+property.
 
 ```html
-<canvas-panel preferred-formats="webp,heif">
+<canvas-panel preferred-formats="webp,heif"></canvas-panel>
 ```
 
 See [Other Options](../future/other-options) for further details.
 
-
 ### preferred-qualities
 
-:::caution
-This is an upcoming feature and may not use your preferred quality chosen and default to `default`
-:::
+:::caution This is an upcoming feature and may not use your preferred quality
+chosen and default to `default` :::
 
-Tell canvas panel to favour one or more qualities when it constructs requests to image services.
+Tell canvas panel to favour one or more qualities when it constructs requests to
+image services.
 
 ```html
-<canvas-panel preferred-formats="bitonal">
+<canvas-panel preferred-formats="bitonal"></canvas-panel>
 ```
 
 See [Other Options](../future/other-options) for further details.
 
 ### style-id
 
-The HTML `id` of a `<style>` element on the containing page. The CSS in that element will then be available to elements inside Canvas Panel.
+The HTML `id` of a `<style>` element on the containing page. The CSS in that
+element will then be available to elements inside Canvas Panel.
 
 ```html
 <style id="my-styles">
-  .my-highlight { background: orange; }
+  .my-highlight {
+    background: orange;
+  }
 </style>
-<canvas-panel style-id="my-styles">
+<canvas-panel style-id="my-styles"></canvas-panel>
 ```
 
 See [Styling](../examples/styling) for further details.
 
 ### debug
 
-In this mode, Canvas Panel will highlight the boxes it uses to determine what's inside the viewport.
+In this mode, Canvas Panel will highlight the boxes it uses to determine what's
+inside the viewport.
 
 ```html
-<canvas-panel debug="true">
+<canvas-panel debug="true"></canvas-panel>
 ```
 
 ### preset
 
-The `preset` attribute is a way of referencing a block of configuration data. There are three patterns for this:
+The `preset` attribute is a way of referencing a block of configuration data.
+There are three patterns for this:
 
 ```html
 <!-- 1. A block of JSON defined in a <script type="application/json"> tag with the same id -->
@@ -114,31 +124,36 @@ See [Responsive Images](../examples/rendering-modes) for further details.
 
 ### responsive
 
-If responsive is set, the shape of the viewport will match the canvas provided using the width chosen - maintaining the aspect ratio of the image. If you provide a `height` attribute, this will be ignored.
+If responsive is set, the shape of the viewport will match the canvas provided
+using the width chosen - maintaining the aspect ratio of the image. If you
+provide a `height` attribute, this will be ignored.
 
 ```html
-<canvas-panel responsive="true">
+<canvas-panel responsive="true"></canvas-panel>
 ```
 
 See [Responsive Images](../examples/rendering-modes) for further details.
 
 ### interactive
 
-If interative is set to false (default: true) then the user will be able to use their mouse to pan and zoom the image, and their scroll wheel to zoom. 
+If interative is set to false (default: true) then the user will be able to use
+their mouse to pan and zoom the image, and their scroll wheel to zoom.
 
 ```html
-<canvas-panel interactive="true">
+<canvas-panel interactive="true"></canvas-panel>
 ```
 
 See [Responsive Images](../examples/rendering-modes) for further details.
 
 ### class
 
-(className in JavaScript). This can be used for CSS styling or JavaScript selectors, like a normal HTML element.
+(className in JavaScript). This can be used for CSS styling or JavaScript
+selectors, like a normal HTML element.
 
 ### highlight
 
-Accepts the same syntax as the `region` attribute, but draws a box on the canvas, rather than define the viewport.
+Accepts the same syntax as the `region` attribute, but draws a box on the
+canvas, rather than define the viewport.
 
 ```html
 <canvas-panel highlight="1000,1200,900,1340" />
@@ -151,18 +166,29 @@ See [Highlights](../examples/highlighting-regions) for further details.
 A CSS class accessible to Canvas Panel, to be applied to the highlight.
 
 ```html
-<canvas-panel highlight="1000,1200,900,1340" highlight-css-class="my-highlight" />
+<canvas-panel
+  highlight="1000,1200,900,1340"
+  highlight-css-class="my-highlight"
+/>
 ```
 
 See [Highlights](../examples/highlighting-regions) for further details.
 
 ### exact-initial-image
 
-Forces the component to request the image for the initial loading state in a single IIIF Image API call (if the image, or images, have IIIF Image API services).
+Forces the component to request the image for the initial loading state in a
+single IIIF Image API call (if the image, or images, have IIIF Image API
+services).
 
-This will happen in preference to multiple tile requests. This is useful where you know the client will make the same request each time for that image (e.g., the component has a fixed size on the page). Otherwise this is inefficient, and it's better to use tiles.
+This will happen in preference to multiple tile requests. This is useful where
+you know the client will make the same request each time for that image (e.g.,
+the component has a fixed size on the page). Otherwise this is inefficient, and
+it's better to use tiles.
 
-If the component is unable to paint the scene with a single request, it will revert to tile requests. This will happen if the image service does not support arbitrary region requests and does not advertise the required size in its `sizes` list.
+If the component is unable to paint the scene with a single request, it will
+revert to tile requests. This will happen if the image service does not support
+arbitrary region requests and does not advertise the required size in its
+`sizes` list.
 
 ```html
 <canvas-panel exact-initial-image="true" />
@@ -170,7 +196,9 @@ If the component is unable to paint the scene with a single request, it will rev
 
 ### viewport
 
-Viewport mode will act like a viewer where the aspect ratio is different to the content. If you set `viewport="false"` then the aspect ratio of canvas-panel will fit the content. 
+Viewport mode will act like a viewer where the aspect ratio is different to the
+content. If you set `viewport="false"` then the aspect ratio of canvas-panel
+will fit the content.
 
 ```html
 <canvas-panel viewport="true" />
@@ -180,9 +208,15 @@ See [Responsive Images](../examples/rendering-modes) for further details.
 
 ### render
 
-This will change which web technology will be used to render the viewer. These are usually defined in a preset and you don't have to worry about this option. You can have a deep-zoom interactive viewer renderered using the `static` preset (which is `<img />` tags), but you will see a performance hit. 
+This will change which web technology will be used to render the viewer. These
+are usually defined in a preset and you don't have to worry about this option.
+You can have a deep-zoom interactive viewer renderered using the `static` preset
+(which is `<img />` tags), but you will see a performance hit.
 
-`webgl` is an option that will be much faster for deep zoom images, but requires that images have the correct CORS headers for rendering. It may also not be 100% compatible with annotation rendering options. Canvas is a good middleground for deep zoom images with annotations.
+`webgl` is an option that will be much faster for deep zoom images, but requires
+that images have the correct CORS headers for rendering. It may also not be 100%
+compatible with annotation rendering options. Canvas is a good middleground for
+deep zoom images with annotations.
 
 ```html
 <canvas-panel render="static" />
@@ -190,24 +224,26 @@ This will change which web technology will be used to render the viewer. These a
 <canvas-panel render="webgl" />
 ```
 
- webgl: (don't use unless you know what you are doing)
+webgl: (don't use unless you know what you are doing)
 
 ### virtual-sizes
 
-Adds additional `sizes` to the list of `sizes` on any image service used to render the scene, even if they are not in the image service. These virtual sizes conform to the syntax of the IIIF Image API [size](https://iiif.io/api/image/3.0/#42-size) parameter. You can supply a list of virtual sizes by separating them with the `|` character:
+Adds additional `sizes` to the list of `sizes` on any image service used to
+render the scene, even if they are not in the image service. These virtual sizes
+conform to the syntax of the IIIF Image API
+[size](https://iiif.io/api/image/3.0/#42-size) parameter. You can supply a list
+of virtual sizes by separating them with the `|` character:
 
 ```html
-<image-service ...
-  virtual-sizes="500,|880,">
-</image-service>
+<image-service ... virtual-sizes="500,|880,"> </image-service>
 ```
 
 See [Responsive Images](../examples/rendering-modes) for further details.
 
 ### nested, x and y
-This will change where in the viewport the canvas is rendered. This is primarily used in `<layout-container />` for compositions of 
-multiple canvases.
 
+This will change where in the viewport the canvas is rendered. This is primarily
+used in `<layout-container />` for compositions of multiple canvases.
 
 ## Properties only on Image Service
 
@@ -223,11 +259,13 @@ An IIIF Image API endpoint:
 
 ### manifest-id
 
-As most canvases are not independently dereferenceable, this property is used to tell Canvas Panel where the canvas can be found.
+As most canvases are not independently dereferenceable, this property is used to
+tell Canvas Panel where the canvas can be found.
 
 ### canvas-id
 
-The `id` of the canvas to display (usually within a Manifest, but not necessarily).
+The `id` of the canvas to display (usually within a Manifest, but not
+necessarily).
 
 ### follow-annotations
 
@@ -239,35 +277,63 @@ This is the same as `region`.
 
 ### text-selection-enabled
 
-This will enable attached text that has been detected to be selectable. Note: this may affect panning and zooming for users. You may
-need to provide a toggle in your UI to turn this on and off.
+This will enable attached text that has been detected to be selectable. Note:
+this may affect panning and zooming for users. You may need to provide a toggle
+in your UI to turn this on and off.
 
 ### text-enabled
 
-This will load and discover attached text automatically. If text is found it will be available to screenreaders as an alternative to the image viewer. 
+This will load and discover attached text automatically. If text is found it
+will be available to screenreaders as an alternative to the image viewer.
 
 ### iiif-content
 
-This is a content state (encoded or not encoded) that can be used to provide a manifest-id, canvas-id and region together. It can also be a remote URL that resolves to a IIIF content state. This may be useful for CMS integrations where you want to have the IIIF state held somewhere else.
+This is a content state (encoded or not encoded) that can be used to provide a
+manifest-id, canvas-id and region together. It can also be a remote URL that
+resolves to a IIIF content state. This may be useful for CMS integrations where
+you want to have the IIIF state held somewhere else.
 
 ### choice-id
 
-This can mark a known choice as preferred before a manifest is loaded and without using JS events. You can also optionally use a hash parameter to specifity the opacity. For this reason choices with hash parameters are not supported in canvas panel.
+This can mark a known choice as preferred before a manifest is loaded and
+without using JS events. You can also optionally use a hash parameter to
+specifity the opacity. For this reason choices with hash parameters are not
+supported in canvas panel.
 
 ```js
-element.setAttribute('choice-id', 'http://example.org/choice-1#opacity=20')
+element.setAttribute("choice-id", "http://example.org/choice-1#opacity=20");
 ```
 
+### home-cover
+
+This can have the following values:
+
+- `false` - this is the default behaviour
+- `true` - this will center the image within the viewport, similar to CSS
+  object-fit: cover.
+- `start` - This will align the image to the start and cut off the end (either
+  the top or the left).
+- `end` - This will align the image to the end and cut off the start (either the
+  right or the bottom).
 
 ## Zoom status API
 
-Atlas has some internal events that it fires when changes occur in the viewer. The first thing that was done was a bridge to these. As such there are 2 new events (normal addEventListener + detail handling):
-* `go-home`
-* `zoom-to`  (in, out, scroll)
+Atlas has some internal events that it fires when changes occur in the viewer.
+The first thing that was done was a bridge to these. As such there are 2 new
+events (normal addEventListener + detail handling):
 
-Additionally there is a 3rd event: `zoom` . The problem is that when the zoom-to event is fired, the viewport has only just started it's transition. It's very much a notification that "recently a zoom was initiated" more than a precise tracker. For this reason the zoom event.
+- `go-home`
+- `zoom-to` (in, out, scroll)
 
-This will fire once the current transitioning zoom has completed. It contains information on the max/min zoom and booleans for if we have reached the max/min (isMax, isMin). The zoom event also fires when you call zoom-to . It does not fire when a user creates a custom transition.
+Additionally there is a 3rd event: `zoom` . The problem is that when the zoom-to
+event is fired, the viewport has only just started it's transition. It's very
+much a notification that "recently a zoom was initiated" more than a precise
+tracker. For this reason the zoom event.
+
+This will fire once the current transitioning zoom has completed. It contains
+information on the max/min zoom and booleans for if we have reached the max/min
+(isMax, isMin). The zoom event also fires when you call zoom-to . It does not
+fire when a user creates a custom transition.
 
 ```
 el.addEventListener('zoom', ev => {
@@ -280,15 +346,23 @@ el.addEventListener('zoom', ev => {
 })
 ```
 
-There is also `getZoom()` , `getMaxZoom()`  and `getMinZoom()`  on the web component too, in addition to `getZoomInformation()`  which returns them all (max/min/current).
+There is also `getZoom()` , `getMaxZoom()` and `getMinZoom()` on the web
+component too, in addition to `getZoomInformation()` which returns them all
+(max/min/current).
 
 ## Movement API
 
-The goal is to know where the viewport is. So in Atlas there are smooth transitions, and as such when something is transitioning there will be a lot of changes in where the viewport is. There are 2 separate attributes covering this:
-* `move-events="true"` - this attribute will enable the move event, since it is noisy
-* `granular-move-events="true"` - this will enable granular (requires above too)
+The goal is to know where the viewport is. So in Atlas there are smooth
+transitions, and as such when something is transitioning there will be a lot of
+changes in where the viewport is. There are 2 separate attributes covering this:
 
-Since there are so many events, the firing of them is completely opt-in*. The new event is:
+- `move-events="true"` - this attribute will enable the move event, since it is
+  noisy
+- `granular-move-events="true"` - this will enable granular (requires above too)
+
+Since there are so many events, the firing of them is completely opt-in\*. The
+new event is:
+
 ```
 el.addEventListener('move', e => {
   e.detail.x;
@@ -301,28 +375,31 @@ el.addEventListener('move', e => {
 });
 ```
 
-*The granular option will affect performance - you would be better setting up a loop ever N seconds and updating in that way.
-    
+\*The granular option will affect performance - you would be better setting up a
+loop ever N seconds and updating in that way.
 
 ## Setting canvas panel via JSON
 
-All canvas panel properties are exposed as their equivalent camelCase versions in JSON.
+All canvas panel properties are exposed as their equivalent camelCase versions
+in JSON.
 
 So `exact-initial-image` becomes `exactInitialImage`.
 
-As well as supplying properties to canvas panel via attributes and via script, like this...
+As well as supplying properties to canvas panel via attributes and via script,
+like this...
 
 ```html
 <canvas-panel id="cp" height="200" />
 <script>
-    const cp = document.getElementById("cp");
-    cp.width = 400;
+  const cp = document.getElementById("cp");
+  cp.width = 400;
 </script>
 ```
 
-...you can also supply properties by referencing JSON. Suppose you have the following block of JSON: 
+...you can also supply properties by referencing JSON. Suppose you have the
+following block of JSON:
 
-```json 
+```json
 // hosted at example.org/preset.json
 {
   "styleId": "css",
@@ -330,7 +407,7 @@ As well as supplying properties to canvas panel via attributes and via script, l
   "canvasId": "http://example.org/manifest-1/c1",
   "height": 300,
   "media": {
-    "(min-width: 800px)": { 
+    "(min-width: 800px)": {
       "height": 500,
       "manifestId": "http://example.org/manifest-2.json",
       "canvasId": "http://example.org/manifest-2/c1",
@@ -349,6 +426,7 @@ You can supply these properties to canvas panel:
 <canvas-panel preset="https://example.org/preset.json" />
 ```
 
-You can also do this directly on the page in a script block. This may be a more typical approach:
+You can also do this directly on the page in a script block. This may be a more
+typical approach:
 
 <Sandbox project={presetSandbox} />

--- a/packages/canvas-panel/image-service.html
+++ b/packages/canvas-panel/image-service.html
@@ -1,0 +1,53 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <script type="module" src="./src/index.ts"></script>
+
+    <div style="display: flex; gap: 20px">
+      <div>
+        <h3>False</h3>
+        <image-service
+          width="512"
+          height="512"
+          preset="static"
+          src="https://iiif.wellcomecollection.org/image/b18035723_0001.JP2"
+          home-cover="false"
+        ></image-service>
+      </div>
+      <div>
+        <h3>True</h3>
+        <image-service
+          width="512"
+          height="512"
+          preset="static"
+          src="https://iiif.wellcomecollection.org/image/b18035723_0001.JP2"
+          home-cover="true"
+        ></image-service>
+      </div>
+      <div>
+        <h3>Start</h3>
+        <image-service
+          width="512"
+          height="512"
+          preset="static"
+          src="https://iiif.wellcomecollection.org/image/b18035723_0001.JP2"
+          home-cover="start"
+        ></image-service>
+      </div>
+      <div>
+        <h3>End</h3>
+        <image-service
+          width="512"
+          height="512"
+          preset="static"
+          src="https://iiif.wellcomecollection.org/image/b18035723_0001.JP2"
+          home-cover="end"
+        ></image-service>
+      </div>
+    </div>
+  </body>
+</html>

--- a/packages/canvas-panel/package.json
+++ b/packages/canvas-panel/package.json
@@ -17,11 +17,11 @@
     "@iiif/presentation-3": ">=1.0.6",
     "@iiif/vault": "^0.9.18",
     "@iiif/parser": "1.*",
-    "@atlas-viewer/atlas": "2.0.9",
+    "@atlas-viewer/atlas": "2.0.10",
     "nanoid": "3.1.25"
   },
   "dependencies": {
-    "@atlas-viewer/atlas": "2.0.9",
+    "@atlas-viewer/atlas": "2.0.10",
     "@atlas-viewer/iiif-image-api": "^2.1.2",
     "@iiif/presentation-2": "^1.0.4",
     "@iiif/presentation-3": "^1.1.3",

--- a/packages/canvas-panel/src/atlas-components/create-atlas-wrapper.tsx
+++ b/packages/canvas-panel/src/atlas-components/create-atlas-wrapper.tsx
@@ -65,6 +65,10 @@ export function createAtlasWrapper<T = any, C = any>({
           }
         }
 
+        if (instance instanceof Atlas.World) {
+          runtime.world = instance;
+        }
+
         if (!(instance instanceof Atlas.WorldObject)) {
           runtime.pendingUpdate = true;
           if (runtime.world) {

--- a/packages/canvas-panel/src/atlas-components/index.ts
+++ b/packages/canvas-panel/src/atlas-components/index.ts
@@ -2,6 +2,17 @@ import { createAtlasWrapper } from './create-atlas-wrapper';
 import * as Atlas from '@atlas-viewer/atlas';
 import { BoxStyle } from '@atlas-viewer/atlas';
 
+export const World = createAtlasWrapper<{
+  height: number;
+  width: number;
+}>({
+  displayName: 'Atlas.World',
+  component: Atlas.World,
+  customConstructor: (props) => {
+    return new Atlas.World(props.width, props.height);
+  },
+});
+
 export const WorldObject = createAtlasWrapper<{
   height: number;
   scale?: number;

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
@@ -18,7 +18,6 @@ import { ErrorFallback } from '../ErrorFallback/ErrorFallback';
 import { targetToPixels } from '../../helpers/target-to-pixels';
 import { RenderAllCanvases } from '../RenderAllCanvases';
 
-
 const ErrorBoundary = _ErrorBoundary as any;
 
 export function ViewCanvas(props: ViewCanvasProps) {
@@ -117,6 +116,8 @@ export function ViewCanvas(props: ViewCanvasProps) {
         className={props.className}
         {...displayOptions}
         mode={annoMode ? 'sketch' : props.mode}
+        homeCover={props.homeCover}
+        homeOnResize={!!props.homeCover}
       >
         <Component
           isStatic={!props.interactive}

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
@@ -33,4 +33,5 @@ export type ViewCanvasProps = {
   textSelectionEnabled?: boolean;
   disableThumbnail?: boolean;
   skipSizes?: boolean;
+  homeCover?: boolean | 'start' | 'end';
 };

--- a/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
+++ b/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
@@ -115,6 +115,23 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
       parse: parseCSV,
     }
   );
+  const [homeCover] = useSyncedState(props.homeCover, {
+    parse: (value) => {
+      if (value === 'false') {
+        return false;
+      }
+      if (value === 'true') {
+        return true;
+      }
+      if (value === 'start') {
+        return 'start' as const;
+      }
+      if (value === 'end') {
+        return 'end' as const;
+      }
+      return false;
+    },
+  });
   const [mode, setMode] = useSyncedState(props.atlasMode || internalConfig.atlasMode);
   const [isWorldReady, setIsWorldReady] = useState('');
   const [inlineStyles, setInlineStyles] = useState('');
@@ -783,6 +800,7 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
     nested,
     x,
     y,
+    homeCover,
     useProp,
     useRegisterWebComponentApi,
     runtime,

--- a/packages/canvas-panel/src/types/generic-atlas-component.ts
+++ b/packages/canvas-panel/src/types/generic-atlas-component.ts
@@ -22,6 +22,7 @@ export type GenericAtlasComponent<T = Record<never, never>, Props = any> = T & {
   granularMoveEvents?: boolean;
   disableKeyboardNavigation?: boolean;
   clickToEnableZoom?: boolean;
+  homeCover?: 'true' | 'false' | 'start' | 'end';
   viewport?: boolean;
   debug?: boolean;
   media?: Record<string, Partial<GenericAtlasComponent<T>>>;

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -44,6 +44,7 @@ const canvasPanelAttributes = [
   'text-enabled',
   'follow-annotations',
   'iiif-content',
+  'home-cover',
 ];
 
 export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
@@ -64,6 +65,7 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
     interactive,
     x,
     y,
+    homeCover,
     className,
     inlineStyles,
     inlineStyleSheet,
@@ -318,6 +320,7 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
         textSelectionEnabled={textSelectionEnabled}
         disableThumbnail={disableThumbnail}
         skipSizes={skipSizes}
+        homeCover={homeCover}
       >
         <slot name="atlas" />
         {contentStateCallback ? <DrawBox onCreate={onDrawBox} /> : null}

--- a/packages/canvas-panel/src/web-components/image-service.tsx
+++ b/packages/canvas-panel/src/web-components/image-service.tsx
@@ -15,6 +15,7 @@ import { useGenericAtlasProps } from '../hooks/use-generic-atlas-props';
 import { GenericAtlasComponent } from '../types/generic-atlas-component';
 import { parseBool } from '../helpers/parse-attributes';
 import { ImageServiceLoader } from '@atlas-viewer/iiif-image-api';
+import { World } from '../atlas-components';
 
 const ErrorBoundary = _ErrorBoundary as any;
 
@@ -54,6 +55,7 @@ export function ImageService(props: ImageServiceProps) {
     interactive,
     x,
     y,
+    homeCover,
   } = useGenericAtlasProps(props);
 
   const [src] = useProp('src');
@@ -126,6 +128,8 @@ export function ImageService(props: ImageServiceProps) {
           aspectRatio={aspectRatio}
           className={className}
           nested={nested}
+          homeCover={homeCover}
+          homeOnResize={!!homeCover}
           {...atlasProps}
         >
           <RenderImage
@@ -190,6 +194,7 @@ if (typeof window !== 'undefined') {
       'choice-id',
       'move-events',
       'granular-move-events',
+      'home-cover',
       'tile-format',
     ],
     {

--- a/packages/canvas-panel/yarn.lock
+++ b/packages/canvas-panel/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atlas-viewer/atlas@2.0.9", "@atlas-viewer/atlas@^2.0.0-alpha.19":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@atlas-viewer/atlas/-/atlas-2.0.9.tgz#5177126c94b9bf859756707fee42662220e0aa2d"
-  integrity sha512-HJLQ3raHXFppLAVPzxtKr58UxBkOuOX3Ph3++gLqpkNOMCJL1T3Xi51fhMj5SObck8TfmNKI8/sDaL2QfU9gwQ==
+"@atlas-viewer/atlas@2.0.10", "@atlas-viewer/atlas@^2.0.0-alpha.19":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@atlas-viewer/atlas/-/atlas-2.0.10.tgz#911adcd31e45150ff13702b74c7a410fcbdcdef5"
+  integrity sha512-ziyXUrQ2XlQQ7WQT9ssIgkM/bWiYpRxvBOk6aZ1nqHuOkPtSObUTyBqxLBFimE+D3+0+72pcP+eBx4B8Hc8IWg==
   dependencies:
     "@atlas-viewer/dna" "^0.5.0"
     "@atlas-viewer/iiif-image-api" "^2.0.5"


### PR DESCRIPTION
New property that will position an image within a viewport similar to CSS `object-fit` property. There are 4 modes:
- `false` - current behaviour
- `true` - Aligns to the middle
- `start` - Aligns to the top or the left
- `end` - Aligns to the bottom or the right


![image](https://github.com/digirati-co-uk/iiif-canvas-panel/assets/8266711/6f043957-df52-4e78-8e42-ee4880538a08)
