### PR TITLE
adding support for complex choices

### DIFF
--- a/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
+++ b/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
@@ -125,8 +125,14 @@ export function AtlasCanvas({
             })) as any[],
             label: (ref as any).label,
           };
-          choiceEventChannel.emit('onChoiceChange', { choice });
-
+          choiceEventChannel.emit('onChoiceChange', {
+            choice,
+            partOf: {
+              canvasId: canvas.id,
+              choiceId: body.id,
+              manifestId: manifest?.id,
+            },
+          });
         }
       }
       // this returns 1 choice

--- a/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
+++ b/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
@@ -11,8 +11,7 @@ import {
   useAnnotationPageManager,
   useManifest,
 } from 'react-iiif-vault';
-import { createStylesHelper, SingleChoice } from '@iiif/vault-helpers';
-import { createPaintingAnnotationsHelper } from '@iiif/vault-helpers';
+import { createStylesHelper, SingleChoice, createPaintingAnnotationsHelper } from '@iiif/vault-helpers';
 import { Fragment, h } from 'preact';
 import { WorldObject, SingleImage } from '../../atlas-components';
 import { RenderAnnotationPage } from '../RenderAnnotationPage/RenderAnnotationPage';
@@ -75,7 +74,6 @@ export function AtlasCanvas({
     defaultChoices: defaultChoices?.map(({ id }) => id),
   });
 
-  const choice = strategy.type === 'images' ? strategy.choice : undefined;
   const manager = useAnnotationPageManager(manifest?.id || canvas?.id);
   const fullPages = useVaultSelector(
     (state, vault) => {

--- a/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
+++ b/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
@@ -105,43 +105,36 @@ export function AtlasCanvas({
           const body = vault.get(ref) as any;
           const type = (body.type || 'unknown').toLowerCase();
           // Choice
-          if (type === 'choice') {
-            const extra = { parent: body.id };
-            const nestedBodies = vault.get(body.items) as ContentResource[];
-            console.log(nestedBodies);
-            // // Which are active? By default, the first, but we could push multiple here.
-
-            // this doesn't respect current selections... 
-            const selected = enabledChoices.length
-              ? enabledChoices.map((cid) => nestedBodies.find((b) => b.id === cid)).filter(Boolean)
-              : [nestedBodies[0]];
-
-            if (selected.length === 0) {
-              selected.push(nestedBodies[0]);
-            }
-
-            // Store choice.
-            const choice: SingleChoice = {
-              type: 'single-choice',
-              items: nestedBodies.map((b) => ({
-                id: b.id,
-                label: (b as any).label as any,
-                selected: selected.indexOf(b) !== -1,
-              })) as any[],
-              label: (ref as any).label,
-            };
-            choiceEventChannel.emit('onChoiceChange', { choice });
-            // // @todo insert in the right order.
-            // references.push(...(selected as any[]));
-
+          if (type !== 'choice') {
             continue;
           }
+          const nestedBodies = vault.get(body.items) as ContentResource[];
+
+          // if the enabledChoices has the id, then turn it on, otherwise choose the 1st item
+          const selected = enabledChoices.length
+            ? enabledChoices.map((cid) => nestedBodies.find((b) => b.id === cid)).filter(Boolean)
+            : [nestedBodies[0]];
+
+          if (selected.length === 0) {
+            selected.push(nestedBodies[0]);
+          }
+          const choice: SingleChoice = {
+            type: 'single-choice',
+            items: nestedBodies.map((b) => ({
+              id: b.id,
+              label: (b as any).label as any,
+              selected: selected.indexOf(b) !== -1,
+            })) as any[],
+            label: (ref as any).label,
+          };
+          choiceEventChannel.emit('onChoiceChange', { choice });
+
         }
       }
       // this returns 1 choice
       const choices = vaulthelper.extractChoices(canvas.id);
     }
-  }, [canvas?.id, defaultChoices]);
+  }, [canvas?.id, actions, defaultChoices]);
 
   const pageTypes = useMemo(() => sortAnnotationPages(manager.availablePageIds, vault as any), fullPages);
   const hasTextLines = !!pageTypes.pageMapping.supplementing?.length;
@@ -178,7 +171,6 @@ export function AtlasCanvas({
       }
     }
   }, [defaultChoices]);
-
 
   const thumbnail = useThumbnail({ maxWidth: 256, maxHeight: 256 });
 

--- a/packages/canvas-panel/src/helpers/eventbus.ts
+++ b/packages/canvas-panel/src/helpers/eventbus.ts
@@ -30,7 +30,14 @@ export const choiceEventChannel = eventbus<{
    * @param payload - the id and options for the choice
    *
    */
-  onChoiceChange: (payload: { choice?: ChoiceDescription }) => void;
+  onChoiceChange: (payload: {
+    choice?: ChoiceDescription;
+    partOf?: {
+      choiceId?: string;
+      canvasId?: string;
+      manifestId?: string;
+    };
+  }) => void;
   /**
    * When a canvas is changed, or a sequence is changed, this signals that
    * the current set of choices should be reset

--- a/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
+++ b/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
@@ -155,7 +155,7 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
       seenChoices.current = {};
     });
 
-    const onChoiceChange = (payload: { choice?: ChoiceDescription }) => {
+    const onChoiceChange = (payload: { choice?: ChoiceDescription, partOf?: any }) => {
       const choice = payload.choice;
       // sort the choices by ID in order to help with de-duping
       if (webComponent?.current && choice && choice.items) {
@@ -181,6 +181,7 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
         (seenChoices.current as any)[key] = value;
         // move this outside the IF if we want to fire on every page
 
+        (choice as any).partOf = payload.partOf;
         webComponent.current.dispatchEvent(new CustomEvent('choice', { detail: { choice } }));
       }
     };

--- a/packages/storybook/src/stories/sequence-panel.stories.tsx
+++ b/packages/storybook/src/stories/sequence-panel.stories.tsx
@@ -62,7 +62,7 @@ export const SequencePanel = () => {
 
 
 
-const bayard="https://gist.githubusercontent.com/danieltbrennan/183d6cbb0948948413394cf116e5844a/raw/11fdda729f0c2960ee1d971902cdf0badd7f31df/bayard_w_choices.json"
+const bayard="https://data.getty.edu/media/manifest/bayard-custom"
 
 export const MakingChoice = () => {
   const viewer = useRef()
@@ -135,6 +135,7 @@ export const MakingChoice = () => {
     <div>
     <button onClick={() => viewer.current.sequence.setCurrentCanvasIndex(3)}>Go to: Canvas Index 3</button>
     <button onClick={() => viewer.current.sequence.setCurrentCanvasIndex(11)}>Go to: Canvas Index 11</button>
+    <button onClick={() => viewer.current.sequence.setCurrentCanvasIndex(28)}>Go to: Canvas Index 28</button>
     <button onClick={() => viewer.current.sequence.previousCanvas()}>Prev</button>
     <button onClick={() => viewer.current.sequence.nextCanvas()}>Next</button>
       


### PR DESCRIPTION
@stephenwf another bug from the complexity of choices... Canvas 28 of the bayard manifest (see the choices story) has 2 different choices on the same page.  But, the IIIFHelpers don't return all of those choices (there's an assumption of a single choice).  This brings some of that logic internally to CanvasPanel so we can pull the choices from Vault directly... 

- ~As I think you've identified, we do need some means to maintain state so that when you choose one choice it doesn't flip the other one back... working on that before this is ready.~ _the more I've thought about this, implementing state really goes against the choiceOptions (Disable / Disable all), if we do something here to maintain some choice logic, then I think we're putting the logic here while it should be in the implementing application_
- also curious about your thoughts about the upstream implications of `getPaintables` and `extractChoices` returning an array instead of an object (or alternately overloading the return to return an object if just one, and an array if more than one -- more backward compatible, but more complex implementation in more places)_.