### PR TITLE
identifying two bugs

### DIFF
--- a/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
+++ b/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
@@ -172,7 +172,7 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
       seenChoices.current = {};
     });
 
-    const onChoiceChange = (payload: { choice?: ChoiceDescription, partOf?: any }) => {
+    const onChoiceChange = (payload: { choice?: ChoiceDescription; partOf?: any }) => {
       const choice = payload.choice;
       // sort the choices by ID in order to help with de-duping
       if (webComponent?.current && choice && choice.items) {
@@ -294,7 +294,6 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
     const lastGoodScale = rt._lastGoodScale;
     const minZoom = getMinZoom();
     let canZoomOut = lastGoodScale > minZoom || lastGoodScale * ZOOM_OUT_FACTOR > minZoom;
-
     // for very small canvases, this should allow us to always zoom out to home
     if (
       rt.maxScaleFactor - minZoom < lastGoodScale &&
@@ -306,6 +305,19 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
       canZoomOut = true;
     }
     const canZoomIn = lastGoodScale * ZOOM_IN_FACTOR < 1;
+    console.log({
+      canZoomIn,
+      canZoomOut,
+      lastGoodScale,
+      minZoom,
+      next: lastGoodScale * ZOOM_OUT_FACTOR,
+      worldHeight: rt.world.height,
+      worldWidth: rt.world.width,
+      target: rt.target[4],
+      targetZoomed: rt.getZoomedPosition(ZOOM_IN_FACTOR, {})[4],
+      test: Math.abs(rt.target[4] - rt.getZoomedPosition(ZOOM_IN_FACTOR, {})[4]),
+    });
+
     const detail = {
       canZoomIn,
       canZoomOut,

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -234,6 +234,7 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
             contentState.target[0].selector &&
             contentState.target[0].selector.type === 'BoxSelector'
           ) {
+            console.log('apply selector!', contentState.target[0].selector.spatial);
             runtime.current.world.gotoRegion(contentState.target[0].selector.spatial);
           }
         } else {
@@ -269,13 +270,7 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
           }
           if (firstTarget.selector && runtime.current && webComponent.current) {
             if (firstTarget.selector.type === 'BoxSelector') {
-              const { x, y, width, height } = firstTarget.selector.spatial;
-              runtime.current.world.gotoRegion({
-                x,
-                y,
-                width,
-                height,
-              });
+              runtime.current.world.gotoRegion(firstTarget.selector.spatial);
             } else {
               setParsedTarget(firstTarget);
             }

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -1,4 +1,5 @@
-import '@digirati/canvas-panel-web-components';
+//import '@digirati/canvas-panel-web-components';
+import "../../canvas-panel"
 import { addParameters } from '@storybook/client-api';
 
 addParameters({

--- a/packages/storybook/src/stories/canvas-panel.stories.tsx
+++ b/packages/storybook/src/stories/canvas-panel.stories.tsx
@@ -68,6 +68,43 @@ export const CanvasWithSmallZoom = () => {
   </>
 }
 
+export const CanvasWithLandscapeZoom = () => {
+
+  const [canZoomIn, setCanZoomIn] = useState(false);
+  const [canZoomOut, setCanZoomOut] = useState(false);
+  let panel;
+  useEffect(() => {
+    panel = document.querySelector(selector);
+    
+    panel.addEventListener("world-ready", (e) => {
+      // set the initial state based on the image that's loaded into the canvas
+      const detail = (e as any).detail;
+      setCanZoomIn(detail.canZoomIn);
+      setCanZoomOut(detail.canZoomOut);
+    })
+
+
+    panel.addEventListener("zoom", (e) => {
+      const detail = (e as any).detail;
+      setCanZoomIn(detail.canZoomIn);
+      setCanZoomOut(detail.canZoomOut);
+    });
+    allEvents.forEach(type => {
+      panel.addEventListener(type, (e) => { action(type)(e) });
+    })
+
+  }, [document.querySelector(selector) !== undefined]);
+
+
+  return <>
+    <button disabled={!canZoomIn} onClick={() => (document?.querySelector(selector) as any).zoomIn()}>Zoom In</button> 
+    <button disabled={!canZoomOut} onClick={() => (document?.querySelector(selector) as any).zoomOut()}>Zoom Out</button>
+    {/* @ts-ignore */}
+    <canvas-panel manifest-id='https://media.getty.edu/iiif/manifest/6a744965-6345-41cf-8885-69dd07e25008' canvas-id='https://media.getty.edu/iiif/manifest/78697a2b-31b0-47d9-b1b6-32d7fd67d12c' />
+  </>
+}
+
+
 export const CanvasWithSkipSizes = () => {
 
 
@@ -123,6 +160,39 @@ export const CanvasWithSkipSizes = () => {
   </>
 
 }
+
+const contentStateNarrowViewport = "JTdCJTIyaWQlMjIlM0ElMjJodHRwcyUzQSUyRiUyRmlpaWYud2VsbGNvbWVjb2xsZWN0aW9uLm9yZyUyRnByZXNlbnRhdGlvbiUyRmIxODAzNTcyMyUyRmNhbnZhc2VzJTJGYjE4MDM1NzIzXzAwMDEuSlAyJTIzeHl3aCUzRC0xNTI3LjE4Njg4OTY0ODQzNzUlMkM2MTQuODI0NDYyODkwNjI1JTJDNTE2Ni4wOTA0NTQxMDE1NjI1JTJDMjIzNC4wMzgzMzAwNzgxMjUlMjIlMkMlMjJ0eXBlJTIyJTNBJTIyQ2FudmFzJTIyJTJDJTIycGFydE9mJTIyJTNBJTVCJTdCJTIyaWQlMjIlM0ElMjJodHRwcyUzQSUyRiUyRmlpaWYud2VsbGNvbWVjb2xsZWN0aW9uLm9yZyUyRnByZXNlbnRhdGlvbiUyRmIxODAzNTcyMyUyMiUyQyUyMnR5cGUlMjIlM0ElMjJNYW5pZmVzdCUyMiU3RCU1RCU3RA";
+const contentStateWideViewport = "JTdCJTIyaWQlMjIlM0ElMjJodHRwcyUzQSUyRiUyRmlpaWYud2VsbGNvbWVjb2xsZWN0aW9uLm9yZyUyRnByZXNlbnRhdGlvbiUyRmIxODAzNTcyMyUyRmNhbnZhc2VzJTJGYjE4MDM1NzIzXzAwMDEuSlAyJTIzeHl3aCUzRC04MTQ5JTJDMCUyQzE4ODY3JTJDMzU0MyUyMiUyQyUyMnR5cGUlMjIlM0ElMjJDYW52YXMlMjIlMkMlMjJwYXJ0T2YlMjIlM0ElNUIlN0IlMjJpZCUyMiUzQSUyMmh0dHBzJTNBJTJGJTJGaWlpZi53ZWxsY29tZWNvbGxlY3Rpb24ub3JnJTJGcHJlc2VudGF0aW9uJTJGYjE4MDM1NzIzJTIyJTJDJTIydHlwZSUyMiUzQSUyMk1hbmlmZXN0JTIyJTdEJTVEJTdE"
+
+export const CanvasWithMultipleContentStates = () => {
+
+
+  const manifestUrl = welcome;
+
+  let panel;
+  let count = 0;
+  useEffect(() => {
+    panel = document.querySelector(selector);
+    panel.addEventListener("world-ready", (e) => {
+    })
+
+
+    allEvents.forEach(type => {
+      panel.addEventListener(type, (e) => { action(type)(e) });
+    })
+
+  }, [document.querySelector(selector) !== undefined]);
+  {/* @ts-ignore */ }
+
+  return <>
+    <button onClick={()=> panel.setContentStateFromText(contentStateNarrowViewport)} >Narrow</button>
+    <button onClick={()=> panel.setContentStateFromText(contentStateWideViewport)} >Wide</button>
+    {/* @ts-ignore */}
+    <canvas-panel manifest-id={welcome} canvas-id={ canvases[0]} skip-sizes='true' />
+  </>
+
+}
+
 
 
 export const CanvasWithContentState = () => {


### PR DESCRIPTION
trying to create stories and content that allow us to identify two bugs we’ve seen as we expose CanvasPanel.

1. For certain landscape images we’re seeing the zoom out calculation logic is still not 100% right.  Adding some debug in `use-generic-atlas-props ` to isolate that area of the code AND the `CanvasWithLandscapeZoom` story which shows that quite well.

2. We’re using the ContentState API to allow for clean transitions to full-screen and back. But, I believe because the viewport is a significantly different ratio that this is not working properly. a. The user experience is also quite awkward with the image bouncing (perhaps we can set the transition to immediate), or expose that as an option? b. it feels like the image is also not positioned with the center of the target area in the center of the viewport (this feels like an atlas bug)