### PR TITLE
allow setContentStateFromText to be immediate

### DIFF
--- a/packages/canvas-panel/src/helpers/content-state/content-state.ts
+++ b/packages/canvas-panel/src/helpers/content-state/content-state.ts
@@ -26,6 +26,7 @@ export type NormalisedContentState = {
   motivation: ['contentState', ...string[]];
   target: Array<SupportedTarget>;
   extensions: Record<string, any>;
+  immediate?: boolean;
 };
 
 /**

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -219,11 +219,12 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
         contentStateStack.current = [];
       },
 
-      setContentStateFromText(text: string) {
+      setContentStateFromText(text: string, immediate = false) {
         if (text == undefined || text.trim() === '') {
           return;
         }
         const contentState = normaliseContentState(parseContentState(text));
+        contentState.immediate = immediate;
         const firstTarget = contentState.target[0];
 
         if (canvasIdRef.current === firstTarget.source.id) {
@@ -234,7 +235,7 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
             contentState.target[0].selector &&
             contentState.target[0].selector.type === 'BoxSelector'
           ) {
-            runtime.current.world.gotoRegion(contentState.target[0].selector.spatial);
+            runtime.current.world.gotoRegion({ ...contentState.target[0].selector.spatial, immediate });
           }
         } else {
           setParsedContentState(contentState);
@@ -275,6 +276,7 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
                 y,
                 width,
                 height,
+                immediate: contentState.immediate,
               });
             } else {
               setParsedTarget(firstTarget);

--- a/packages/canvas-panel/src/web-components/sequence-panel.tsx
+++ b/packages/canvas-panel/src/web-components/sequence-panel.tsx
@@ -120,11 +120,12 @@ export function SequencePanel(props: SequencePanelProps) {
         return ContentStateEvent;
       },
 
-      setContentStateFromText(text: string) {
+      setContentStateFromText(text: string, immediate = false) {
         if (text == undefined || text.trim() === '') {
           return;
         }
         const contentState = normaliseContentState(parseContentState(text));
+        contentState.immediate = immediate;
         setParsedContentState(contentState);
       },
 
@@ -185,6 +186,7 @@ export function SequencePanel(props: SequencePanelProps) {
               y,
               width,
               height,
+              immediate: contentState.immediate,
             });
           }
         }

--- a/packages/storybook/src/stories/canvas-panel.stories.tsx
+++ b/packages/storybook/src/stories/canvas-panel.stories.tsx
@@ -138,7 +138,7 @@ export const CanvasWithMultipleContentStates = () => {
     manifestUrl: welcome,
     skipSizes: true,
     extra: () => <>
-      <button onClick={()=> (document?.querySelector(selector) as any).setContentStateFromText(contentStateNarrowViewport)} >Narrow</button>
+      <button onClick={()=> (document?.querySelector(selector) as any).setContentStateFromText(contentStateNarrowViewport,true)} >Narrow</button>
       <button onClick={()=> (document?.querySelector(selector) as any).setContentStateFromText(contentStateWideViewport)} >Wide</button>
     </>
   }


### PR DESCRIPTION
We have a use-case for content-state to be updated immediately when switching to a full-screen behavior. This should allow that to be possible... there may still be places where the behavior is not matching our intent esp when the viewport is different between the captured state and the applied state, but setting this up as an initial case 

https://github.com/digirati-co-uk/iiif-canvas-panel/assets/192686/a5a9b356-2f7e-400e-9ecf-9546ab8d3e9d

