### PR TITLE
remove console log

### DIFF
--- a/packages/canvas-panel/src/components/NestedAtlas/NestedAtlas.tsx
+++ b/packages/canvas-panel/src/components/NestedAtlas/NestedAtlas.tsx
@@ -37,8 +37,6 @@ export function NestedAtlas({
     );
   }
   
-  console.log('bg', props.background);
-
   return (
     <InAtlasContext.Provider value={true}>
       <AtlasAuto


### PR DESCRIPTION
This does a tiny bit of cleanup that we missed -- it removes the console.log on the background change in NestedAtlas