### PR TITLE
Enable configurable tile size calculation

### DIFF
--- a/packages/canvas-panel/package.json
+++ b/packages/canvas-panel/package.json
@@ -17,11 +17,11 @@
     "@iiif/presentation-3": ">=1.0.6",
     "@iiif/vault": "^0.9.18",
     "@iiif/parser": "1.*",
-    "@atlas-viewer/atlas": "2.0.16",
+    "@atlas-viewer/atlas": "2.0.17",
     "nanoid": "3.1.25"
   },
   "dependencies": {
-    "@atlas-viewer/atlas": "https://pkg.csb.dev/atlas-viewer/atlas/commit/f2dbf380/@atlas-viewer/atlas",
+    "@atlas-viewer/atlas": "^2.0.17",
     "@atlas-viewer/iiif-image-api": "^2.1.2",
     "@iiif/presentation-2": "^1.0.4",
     "@iiif/presentation-3": "^1.1.3",

--- a/packages/canvas-panel/package.json
+++ b/packages/canvas-panel/package.json
@@ -21,7 +21,7 @@
     "nanoid": "3.1.25"
   },
   "dependencies": {
-    "@atlas-viewer/atlas": "^2.0.16",
+    "@atlas-viewer/atlas": "https://pkg.csb.dev/atlas-viewer/atlas/commit/f2dbf380/@atlas-viewer/atlas",
     "@atlas-viewer/iiif-image-api": "^2.1.2",
     "@iiif/presentation-2": "^1.0.4",
     "@iiif/presentation-3": "^1.1.3",
@@ -29,9 +29,11 @@
     "@iiif/vault-helpers": "^0.9.11",
     "@preact/compat": "17.*",
     "@react-hook/media-query": "^1.1.1",
+    "add": "^2.0.6",
     "preact": "^10.*",
     "react-error-boundary": "^3.1.4",
-    "react-iiif-vault": "^0.9.21"
+    "react-iiif-vault": "^0.9.21",
+    "yarn": "^1.22.22"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.3.0",

--- a/packages/canvas-panel/package.json
+++ b/packages/canvas-panel/package.json
@@ -29,11 +29,9 @@
     "@iiif/vault-helpers": "^0.9.11",
     "@preact/compat": "17.*",
     "@react-hook/media-query": "^1.1.1",
-    "add": "^2.0.6",
     "preact": "^10.*",
     "react-error-boundary": "^3.1.4",
-    "react-iiif-vault": "^0.9.21",
-    "yarn": "^1.22.22"
+    "react-iiif-vault": "^0.9.21"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.3.0",

--- a/packages/canvas-panel/src/atlas-components/TileSet/TileSet.tsx
+++ b/packages/canvas-panel/src/atlas-components/TileSet/TileSet.tsx
@@ -16,6 +16,7 @@ export const TileSet: FC<{
   skipSizes?: boolean;
   skipThumbnail?: boolean;
   rotation: number;
+  useFloorCalc?: boolean;
 }> = ({
   height,
   tiles,
@@ -26,6 +27,7 @@ export const TileSet: FC<{
   skipSizes = false,
   skipThumbnail = false,
   rotation = 0,
+  useFloorCalc = false,
   viewport,
   tileFormat,
   children,
@@ -127,6 +129,7 @@ export const TileSet: FC<{
                 scaleFactor={size}
                 style={style}
                 format={tileFormat}
+                useFloorCalc={useFloorCalc}
               />
             );
           })

--- a/packages/canvas-panel/src/atlas-components/index.ts
+++ b/packages/canvas-panel/src/atlas-components/index.ts
@@ -97,11 +97,12 @@ export const TiledImage = createAtlasWrapper<{
   scaleFactor: number;
   style?: any;
   format?: string;
+  useFloorCalc?: boolean;
 }>({
   displayName: 'Atlas.TiledImage',
   component: Atlas.TiledImage,
   customConstructor: (props) => {
-    return Atlas.TiledImage.fromTile(props.uri, props.display, props.tile, props.scaleFactor, undefined, props.format);
+    return Atlas.TiledImage.fromTile(props.uri, props.display, props.tile, props.scaleFactor, undefined, props.format, props.useFloorCalc);
   },
 });
 

--- a/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
+++ b/packages/canvas-panel/src/components/AtlasCanvas/AtlasCanvas.tsx
@@ -46,6 +46,7 @@ interface AtlasCanvasProps {
   disableThumbnail?: boolean;
   skipSizes?: boolean;
   rotation?: number;
+  useFloorCalc?: boolean;
 }
 
 export function AtlasCanvas({
@@ -64,6 +65,7 @@ export function AtlasCanvas({
   disableThumbnail,
   skipSizes,
   rotation,
+  useFloorCalc,
 }: AtlasCanvasProps) {
   const manifest = useManifest();
   const canvas = useCanvas();
@@ -281,6 +283,7 @@ export function AtlasCanvas({
                 annotations={annotations}
                 skipSizes={skipSizes}
                 skipThumbnail={disableThumbnail}
+                useFloorCalc={useFloorCalc}
               />
             );
           })

--- a/packages/canvas-panel/src/components/RenderImage/RenderImage.tsx
+++ b/packages/canvas-panel/src/components/RenderImage/RenderImage.tsx
@@ -22,6 +22,7 @@ export function RenderImage({
   skipSizes,
   annotationId,
   skipThumbnail,
+  useFloorCalc,
 }: {
   id: string;
   image: ImageWithOptionalService;
@@ -36,6 +37,7 @@ export function RenderImage({
   skipSizes?: boolean;
   annotationId?: string;
   skipThumbnail?: boolean;
+  useFloorCalc?: boolean;
 }) {
   // For image resources, we may not support everything.. but we do support opacity.
   const annotationStyles = useStyles(annotationId ? { id: annotationId, type: 'Annotation' } : undefined, 'atlas');
@@ -80,6 +82,7 @@ export function RenderImage({
             x={image.target?.spatial.x + x}
             y={image.target?.spatial.y + y}
             rotation={rotation}
+            useFloorCalc={useFloorCalc}
             width={image.target?.spatial.width}
             height={image.target?.spatial.height}
             style={style}

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.tsx
@@ -132,6 +132,7 @@ export function ViewCanvas(props: ViewCanvasProps) {
           disableThumbnail={props.disableThumbnail}
           skipSizes={props.skipSizes}
           rotation={rotation}
+          useFloorCalc={props.useFloorCalc}
           onCreated={(e: any) => {
             if (manifest && canvas && e) {
               navigator.clipboard.writeText(

--- a/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
+++ b/packages/canvas-panel/src/components/ViewCanvas/ViewCanvas.types.ts
@@ -37,4 +37,5 @@ export type ViewCanvasProps = {
   skipSizes?: boolean;
   homeCover?: boolean | 'start' | 'end';
   rotation?: number;
+  useFloorCalc?: boolean;
 };

--- a/packages/canvas-panel/src/web-components/canvas-panel.tsx
+++ b/packages/canvas-panel/src/web-components/canvas-panel.tsx
@@ -31,6 +31,7 @@ export type CanvasPanelProps = GenericAtlasComponent<
     followAnnotations?: boolean;
     iiifContent?: string;
     rotation?: number;
+    useFloorCalc?: 'true' | 'false' | boolean
   },
   UseRegisterPublicApi['properties']
 >;
@@ -92,6 +93,7 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
   const [disableThumbnail] = useProp('disableThumbnail', { parse: parseBool, defaultValue: false });
   const [skipSizes] = useProp('skipSizes', { parse: parseBool, defaultValue: false });
   const [textEnabled] = useProp('textEnabled', { parse: parseBool, defaultValue: false });
+  const [useFloorCalc] = useProp('useFloorCalc', { parse: parseBool, defaultValue: false });
   const contentState =
     unknownContentState && unknownContentState.type !== 'remote-content-state' ? unknownContentState : null;
   const contentStateToLoad =
@@ -330,6 +332,7 @@ export const CanvasPanel: FC<CanvasPanelProps> = (props) => {
         disableThumbnail={disableThumbnail}
         skipSizes={skipSizes}
         homeCover={homeCover}
+        useFloorCalc={useFloorCalc}
       >
         <slot name="atlas" />
         {contentStateCallback ? <DrawBox onCreate={onDrawBox} /> : null}

--- a/packages/canvas-panel/yarn.lock
+++ b/packages/canvas-panel/yarn.lock
@@ -26,22 +26,6 @@
     react-use-measure "^2.0.1"
     scheduler "^0.21.0"
 
-"@atlas-viewer/atlas@^2.0.16":
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/@atlas-viewer/atlas/-/atlas-2.2.9.tgz#40ead5b5c23952ac4904e2bbb04dead7401508e6"
-  integrity sha512-UqtyxcfIMx8MbXWTVwBIFOL5Dz9BacBWpUWNkOOefC6/9FWKwitCm7L15ZvosyVwGN+UsexeAuyV5mNh45lTvg==
-  dependencies:
-    "@atlas-viewer/dna" "^0.5.0"
-    "@atlas-viewer/iiif-image-api" "^2.2.0"
-    "@iiif/helpers" "^1.1.0"
-    "@iiif/parser" "^2.1.0"
-    "@iiif/presentation-3" ">=2"
-    lru-cache "^7.17.0"
-    normalize-wheel "^1.0.1"
-    react-reconciler "^0.29.0"
-    react-use-measure "^2.0.1"
-    scheduler "^0.21.0"
-
 "@atlas-viewer/atlas@https://pkg.csb.dev/atlas-viewer/atlas/commit/f2dbf380/@atlas-viewer/atlas":
   version "2.2.8"
   resolved "https://pkg.csb.dev/atlas-viewer/atlas/commit/f2dbf380/@atlas-viewer/atlas#d2e5344deaa96c6e01c54ab75c3989caa5a9ec9b"
@@ -1445,11 +1429,6 @@ acorn@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
-
-add@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
-  integrity sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q==
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -4459,8 +4438,3 @@ yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
-
-yarn@^1.22.22:
-  version "1.22.22"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz#ac34549e6aa8e7ead463a7407e1c7390f61a6610"
-  integrity sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==

--- a/packages/canvas-panel/yarn.lock
+++ b/packages/canvas-panel/yarn.lock
@@ -42,6 +42,21 @@
     react-use-measure "^2.0.1"
     scheduler "^0.21.0"
 
+"@atlas-viewer/atlas@https://pkg.csb.dev/atlas-viewer/atlas/commit/f2dbf380/@atlas-viewer/atlas":
+  version "2.2.8"
+  resolved "https://pkg.csb.dev/atlas-viewer/atlas/commit/f2dbf380/@atlas-viewer/atlas#d2e5344deaa96c6e01c54ab75c3989caa5a9ec9b"
+  dependencies:
+    "@atlas-viewer/dna" "^0.5.0"
+    "@atlas-viewer/iiif-image-api" "^2.2.0"
+    "@iiif/helpers" "^1.1.0"
+    "@iiif/parser" "^2.1.0"
+    "@iiif/presentation-3" ">=2"
+    lru-cache "^7.17.0"
+    normalize-wheel "^1.0.1"
+    react-reconciler "^0.29.0"
+    react-use-measure "^2.0.1"
+    scheduler "^0.21.0"
+
 "@atlas-viewer/dna@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@atlas-viewer/dna/-/dna-0.5.0.tgz#aab824540b59dc3897e2ba4cdb51a53e47ed3311"
@@ -1430,6 +1445,11 @@ acorn@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q==
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -4439,3 +4459,8 @@ yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yarn@^1.22.22:
+  version "1.22.22"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz#ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  integrity sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==

--- a/packages/canvas-panel/yarn.lock
+++ b/packages/canvas-panel/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atlas-viewer/atlas@2.0.16", "@atlas-viewer/atlas@^2.0.0-alpha.19":
-  version "2.0.16"
-  resolved "https://registry.yarnpkg.com/@atlas-viewer/atlas/-/atlas-2.0.16.tgz#353c572a453b9ddd43a70e1cdfeb71ac335c3176"
-  integrity sha512-6GfaPiSYi5DhgT7Lfcl9VJBfeuDW0qRc5icQ7OXTFk/lvTImeFs9mhcPNZ5+o6xxw5F5aoa49lZipXSUNPQc9A==
+"@atlas-viewer/atlas@2.0.17", "@atlas-viewer/atlas@^2.0.0-alpha.19":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@atlas-viewer/atlas/-/atlas-2.0.17.tgz#d4eb62b96f5d475aa2a15903556df1bad213c983"
+  integrity sha512-15fJaS/lNbeAVEf6YNntwnZqHOUtDTfbtfLdNUDgz1MDCEuu8TXrPx8LZmOpIBPSAWrC99UmBkSKsrMj/8Q0gA==
   dependencies:
     "@atlas-viewer/dna" "^0.5.0"
     "@atlas-viewer/iiif-image-api" "^2.0.5"
@@ -26,27 +26,12 @@
     react-use-measure "^2.0.1"
     scheduler "^0.21.0"
 
-"@atlas-viewer/atlas@https://pkg.csb.dev/atlas-viewer/atlas/commit/f2dbf380/@atlas-viewer/atlas":
-  version "2.2.8"
-  resolved "https://pkg.csb.dev/atlas-viewer/atlas/commit/f2dbf380/@atlas-viewer/atlas#d2e5344deaa96c6e01c54ab75c3989caa5a9ec9b"
-  dependencies:
-    "@atlas-viewer/dna" "^0.5.0"
-    "@atlas-viewer/iiif-image-api" "^2.2.0"
-    "@iiif/helpers" "^1.1.0"
-    "@iiif/parser" "^2.1.0"
-    "@iiif/presentation-3" ">=2"
-    lru-cache "^7.17.0"
-    normalize-wheel "^1.0.1"
-    react-reconciler "^0.29.0"
-    react-use-measure "^2.0.1"
-    scheduler "^0.21.0"
-
 "@atlas-viewer/dna@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@atlas-viewer/dna/-/dna-0.5.0.tgz#aab824540b59dc3897e2ba4cdb51a53e47ed3311"
   integrity sha512-vHyMwXoCFq6ymk+wOVIkMphUo+I+wBRoA2tBf1AIUZWJMsk51cBtO2qzOaZQUh/TmrzrqEY5aEAtgBj52LVRUg==
 
-"@atlas-viewer/iiif-image-api@2.*", "@atlas-viewer/iiif-image-api@^2.0.5", "@atlas-viewer/iiif-image-api@^2.1.2", "@atlas-viewer/iiif-image-api@^2.2.0":
+"@atlas-viewer/iiif-image-api@2.*", "@atlas-viewer/iiif-image-api@^2.0.5", "@atlas-viewer/iiif-image-api@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@atlas-viewer/iiif-image-api/-/iiif-image-api-2.1.2.tgz#aeca3ac0c0c71f9c89986a22fd1ef50c17090761"
   integrity sha512-PiNSPi8y1Tjgfyy+J2bv/P/CypabeL7/za0qA+urFYRUQ2oEip5JvPoIWpyWVMh7MsXPQ4HdIPOpGzANtxTHXA==
@@ -705,7 +690,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@iiif/helpers@^1.0.3", "@iiif/helpers@^1.1.0":
+"@iiif/helpers@^1.0.3":
   version "1.2.19"
   resolved "https://registry.yarnpkg.com/@iiif/helpers/-/helpers-1.2.19.tgz#25e817cde7664774731a9368f48b6875096434eb"
   integrity sha512-v2NQVHq3Ut1gl66Dap1Qc40nORgC86ebgeV7iuhfxNSfseKMt6yD7r+4jSp0qliWC66kJSyg6d3QM7t4oBsE7A==
@@ -719,7 +704,7 @@
     parse-svg-path "^0.1.2"
     svg-arc-to-cubic-bezier "^3.2.0"
 
-"@iiif/parser@1.*", "@iiif/parser@2.0.1", "@iiif/parser@>=v1.0.13", "@iiif/parser@^1.1.2", "@iiif/parser@^2.1.0":
+"@iiif/parser@1.*", "@iiif/parser@2.0.1", "@iiif/parser@>=v1.0.13", "@iiif/parser@^1.1.2":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@iiif/parser/-/parser-1.0.6.tgz#0f5252b94ba586aade3d6558b5a649fa265fe217"
   integrity sha512-bIdmqe3JwPopL7qEeZk193YNkGaEkkfSR9i/+B7I3MVXkKGE6G80tOWhfQRs/EY3fMzOS8OUFxzAu+aS6CXvEg==

--- a/packages/storybook/src/stories/canvas-panel.stories.tsx
+++ b/packages/storybook/src/stories/canvas-panel.stories.tsx
@@ -12,6 +12,7 @@ const allEvents = ['zoom', 'world-ready', 'choice', 'move', 'canvas-change', 'me
 const selector = "canvas-panel,sequence-panel";
 const saintGines = 'https://media.getty.edu/iiif/manifest/1e0ed47e-5a5b-4ff0-aea0-45abee793a1c';
 const welcome = "https://iiif.wellcomecollection.org/presentation/b18035723";
+const ibis = 'https://media.getty.edu/iiif/manifest/b9f50ca1-2a44-4079-ba62-1bcc3cb6575a'
 
 
 export const ChangingCanvases = () => {
@@ -139,7 +140,7 @@ function ImageViewer(props) {
 
     { canvases[Math.abs(cvindex)] }
     {/* @ts-ignore */}
-    <canvas-panel manifest-id={manifestUrl} skip-sizes={props.skipSizes? props.skipSizes : false} canvas-id={props.canvasId ? props.canvasId : canvases[Math.abs(cvindex)]  } />
+    <canvas-panel manifest-id={manifestUrl} skip-sizes={props.skipSizes? props.skipSizes : false} use-floor-calc={props.useFloorCalc ? props.useFloorCalc : false} canvas-id={props.canvasId ? props.canvasId : canvases[Math.abs(cvindex)]  } />
   </>
 
 }
@@ -149,6 +150,13 @@ export const CanvasWithSkipSizes = () => {
 
 
   return ImageViewer({manifestUrl: saintGines, skipSizes: true})
+
+}
+
+export const CanvasWithFloorCalc = () => {
+
+
+  return ImageViewer({manifestUrl: ibis, skipSizes: true, useFloorCalc: true})
 
 }
 


### PR DESCRIPTION
This adds a boolean `useFloorCalc` prop to CanvasPanel which is then passed to Atlas's `tiledImage.fromTile` function to allow easy switching between `math.round` and `math.floor`. Addresses the issue described in https://github.com/atlas-viewer/atlas/pull/58 and https://github.com/digirati-co-uk/iiif-canvas-panel/issues/275 

For testing purposes this is built with the sandbox build of Atlas from https://github.com/atlas-viewer/atlas/pull/58 until that can be merged.