### PR TITLE
check for embedded image sizes in service

### DIFF
--- a/packages/canvas-panel/src/components/RenderImage/RenderImage.tsx
+++ b/packages/canvas-panel/src/components/RenderImage/RenderImage.tsx
@@ -70,8 +70,12 @@ export function RenderImage({
             viewport={isStatic}
             tiles={{
               id: image.service.id,
-              height: (image.height !== image.service.height ? image.service.height : image.height) as number,
-              width: (image.width !== image.service.width ? image.service.width : image.width) as number,
+              height: (image.height !== image.service.height && image.service.height !== undefined
+                ? image.service.height
+                : image.height) as number,
+              width: (image.width !== image.service.width && image.service.width !== undefined
+                ? image.service.width
+                : image.width) as number,
               imageService: image.service as any,
               thumbnail: !skipThumbnail && thumbnail && thumbnail.type === 'fixed' ? thumbnail : undefined,
             }}

--- a/packages/storybook/src/stories/canvas-panel.stories.tsx
+++ b/packages/storybook/src/stories/canvas-panel.stories.tsx
@@ -13,7 +13,6 @@ const selector = "canvas-panel,sequence-panel";
 const saintGines = 'https://media.getty.edu/iiif/manifest/1e0ed47e-5a5b-4ff0-aea0-45abee793a1c';
 const welcome = "https://iiif.wellcomecollection.org/presentation/b18035723";
 
-
 export const ChangingCanvases = () => {
 
   const [cv, setCv] = useState(canvases[0]);
@@ -91,6 +90,7 @@ function ImageViewer(props) {
   const [zoomInfo, setZoomInfo] = useState({});
   const [canZoomIn, setCanZoomIn] = useState(false);
   const [canZoomOut, setCanZoomOut] = useState(false);
+  const [rotation, setRotation] = useState(0);
 
 
   let panel;
@@ -136,10 +136,11 @@ function ImageViewer(props) {
     <button onClick={() => setCvindex(c => (cvindex + 1) % canvases.length)}>Next Canvas</button>
     <button disabled={!canZoomIn} onClick={() => (document?.querySelector(selector) as any).zoomIn()}>Zoom In</button> 
     <button disabled={!canZoomOut} onClick={() => (document?.querySelector(selector) as any).zoomOut()}>Zoom Out</button>
+    <button onClick={()=>{setRotation((rotation + 90) % 360)}}>Rotate Canvas</button>
 
     { canvases[Math.abs(cvindex)] }
     {/* @ts-ignore */}
-    <canvas-panel manifest-id={manifestUrl} skip-sizes={props.skipSizes? props.skipSizes : false} canvas-id={props.canvasId ? props.canvasId : canvases[Math.abs(cvindex)]  } />
+    <canvas-panel rotation={rotation} manifest-id={manifestUrl} skip-sizes={props.skipSizes? props.skipSizes : false} canvas-id={props.canvasId ? props.canvasId : canvases[Math.abs(cvindex)] } />
   </>
 
 }


### PR DESCRIPTION
Came across a small bug where we can have manifests that lack a sizes array in the image service property, which downstream results in the wrong canvas size being calculated during rotation if the skip-sizes prop is set.