### PR TITLE
emits an error when canvas panel loads the ErrorFallback

### DIFF
--- a/docs/examples/17-reacting-to-the-user.md
+++ b/docs/examples/17-reacting-to-the-user.md
@@ -157,6 +157,11 @@ Extra DEMO:
 - select an annotation and display a sidebar
 - Click on the canvas and display simple coordinates.
 
+## Error(s)
+
+If CanvasPanel has an issue loading a canvas, it should fire a `cp-error` event
+with a `message` and `error` property.
+
 ## Content State
 
 Canvas Panel provides some basic methods for getting and setting the current

--- a/packages/canvas-panel/package.json
+++ b/packages/canvas-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digirati/canvas-panel-web-components",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "typings": "./dist/types/index.d.ts",
   "main": "./dist/bundle.js",
   "files": [

--- a/packages/canvas-panel/package.json
+++ b/packages/canvas-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digirati/canvas-panel-web-components",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "typings": "./dist/types/index.d.ts",
   "main": "./dist/bundle.js",
   "files": [

--- a/packages/canvas-panel/src/components/ErrorFallback/ErrorFallback.tsx
+++ b/packages/canvas-panel/src/components/ErrorFallback/ErrorFallback.tsx
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { FallbackProps } from 'react-error-boundary';
 import { useEffect } from 'preact/compat';
+import { errorEventChannel } from '../../helpers/eventbus';
 
 export function ErrorFallback({
   error,
@@ -14,6 +15,7 @@ export function ErrorFallback({
 
   useEffect(() => {
     console.error(error);
+    errorEventChannel.emit('onErrorEvent', { message: error?.message, error });
   }, [error]);
 
   return (

--- a/packages/canvas-panel/src/helpers/eventbus.ts
+++ b/packages/canvas-panel/src/helpers/eventbus.ts
@@ -46,6 +46,16 @@ export const choiceEventChannel = eventbus<{
   onResetSeen: () => void;
 }>();
 
+export const errorEventChannel = eventbus<{
+  /**
+   * When an `error` is fired
+   *
+   * @param payload - the id and options for the choice
+   *
+   */
+  onErrorEvent: (payload: { message?: string; error: any }) => void;
+}>();
+
 export function eventbus<E extends EventMap>(config?: EventBusConfig): EventBus<E> {
   const bus: Partial<Bus<E>> = {};
 

--- a/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
+++ b/packages/canvas-panel/src/hooks/use-generic-atlas-props.ts
@@ -17,7 +17,7 @@ import { ImageCandidateRequest } from '@atlas-viewer/iiif-image-api';
 import { createEventsHelper, createStylesHelper, createThumbnailHelper } from '@iiif/vault-helpers';
 import { useEffect } from 'preact/compat';
 import { globalVault } from '@iiif/vault';
-import { choiceEventChannel } from '../helpers/eventbus';
+import { choiceEventChannel, errorEventChannel } from '../helpers/eventbus';
 
 export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtlasComponent<T>) {
   const webComponent = useRef<HTMLElement>();
@@ -228,9 +228,19 @@ export function useGenericAtlasProps<T = Record<never, never>>(props: GenericAtl
         webComponent.current.dispatchEvent(new CustomEvent('choice', { detail: { choice } }));
       }
     };
+
+    const onErrorEvent = (payload: { message?: string; error: any }) => {
+      if (webComponent?.current) {
+        webComponent.current.dispatchEvent(
+          new CustomEvent('cp-error', { detail: { message: payload.message, error: payload.error } })
+        );
+      }
+    };
+    const unsubscribeErrorEvent = errorEventChannel.on('onErrorEvent', onErrorEvent);
     const unsubscribeOnChoiceChange = choiceEventChannel.on('onChoiceChange', onChoiceChange);
 
     return () => {
+      unsubscribeErrorEvent();
       unsubscribeOnResetSeen();
       unsubscribeOnChoiceChange();
     };

--- a/packages/storybook/src/stories/canvas-panel.stories.tsx
+++ b/packages/storybook/src/stories/canvas-panel.stories.tsx
@@ -8,7 +8,7 @@ const canvases = [
   "https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0002.JP2",
   "https://iiif.wellcomecollection.org/presentation/b18035723/canvases/b18035723_0003.JP2",
 ]
-const allEvents = ['zoom', 'world-ready', 'choice', 'move', 'canvas-change', 'media', 'ready', 'zoom', 'range-change', 'click'];
+const allEvents = ['zoom', 'world-ready', 'choice', 'move', 'canvas-change', 'media', 'ready', 'zoom', 'range-change', 'click','cp-error'];
 const selector = "canvas-panel,sequence-panel";
 const saintGines = 'https://media.getty.edu/iiif/manifest/1e0ed47e-5a5b-4ff0-aea0-45abee793a1c';
 const welcome = "https://iiif.wellcomecollection.org/presentation/b18035723";
@@ -38,6 +38,15 @@ export const CanvasWithSmallZoom = () => {
     {
       manifestUrl: saintGines,
       canvasId: 'https://media.getty.edu/iiif/manifest/canvas/eaa531a5-e6ea-46a2-b6cd-a161d726f87b.json'
+    }
+  )
+}
+
+export const CanvasWithError = () => {
+
+  return ImageViewer(
+    {
+      manifestUrl: "https://saintgin.es"
     }
   )
 }


### PR DESCRIPTION
This exposes the same ErrorFallback message as an emitted error; it should enable us to better track when there are errors in CanvasPanel that we need to handle in the wrapped application.  I’m firing this as `cp-error` to make sure that it’s not confused with DOM Event Errors