### PR TITLE
updates atlas

### DIFF
--- a/packages/canvas-panel/package.json
+++ b/packages/canvas-panel/package.json
@@ -17,11 +17,11 @@
     "@iiif/presentation-3": ">=1.0.6",
     "@iiif/vault": "^0.9.18",
     "@iiif/parser": "1.*",
-    "@atlas-viewer/atlas": "2.0.17",
+    "@atlas-viewer/atlas": "2.3.7",
     "nanoid": "3.1.25"
   },
   "dependencies": {
-    "@atlas-viewer/atlas": "2.0.17",
+    "@atlas-viewer/atlas": "2.3.7",
     "@atlas-viewer/iiif-image-api": "2.2.2",
     "@iiif/presentation-2": "^1.0.4",
     "@iiif/presentation-3": "^1.1.3",


### PR DESCRIPTION
@stephenwf  would you be able to cut a release pinned to a newer version of Atlas than `2.0.17`? 

We had included a few fixes but once you pinned the version it rolled us back and broke our changes. While you work on the new branch, I was hoping you'd be able to cut a release with a newer version of Atlas.

I'm a little confused how to track which changes were released where but the change we need was included in this PR https://github.com/atlas-viewer/atlas/pull/56

In the interim, would you be able to cut a release that doesn't set us back so far? I was assuming that anything `<3` would still be compatible.

Thanks!